### PR TITLE
docs: fix Scalar response schemas

### DIFF
--- a/docs/api/openapi.json
+++ b/docs/api/openapi.json
@@ -39,35 +39,6 @@
         "type": "object"
       },
       "AnswerContentPayload": {
-        "$defs": {
-          "VoiceAnswerPayload": {
-            "properties": {
-              "cdnId": {
-                "type": "string"
-              },
-              "cdnUrl": {
-                "type": "string"
-              },
-              "type": {
-                "type": "string"
-              },
-              "url": {
-                "type": "string"
-              },
-              "waveform": {
-                "type": "string"
-              }
-            },
-            "required": [
-              "cdnUrl",
-              "waveform",
-              "type",
-              "cdnId",
-              "url"
-            ],
-            "type": "object"
-          }
-        },
         "properties": {
           "position": {
             "format": "int32",
@@ -80,7 +51,7 @@
           "voiceAnswer": {
             "anyOf": [
               {
-                "$ref": "#/components/schemas/AnswerContentPayload/$defs/VoiceAnswerPayload"
+                "$ref": "#/components/schemas/VoiceAnswerPayload"
               },
               {
                 "type": "null"
@@ -142,33 +113,16 @@
         "type": "object"
       },
       "BoundingBox": {
-        "$defs": {
-          "Coordinate": {
-            "properties": {
-              "x": {
-                "default": 0.0,
-                "format": "double",
-                "type": "number"
-              },
-              "y": {
-                "default": 0.0,
-                "format": "double",
-                "type": "number"
-              }
-            },
-            "type": "object"
-          }
-        },
         "properties": {
           "bottomRight": {
-            "$ref": "#/components/schemas/BoundingBox/$defs/Coordinate",
+            "$ref": "#/components/schemas/Coordinate",
             "default": {
               "x": 0.0,
               "y": 0.0
             }
           },
           "topLeft": {
-            "$ref": "#/components/schemas/BoundingBox/$defs/Coordinate",
+            "$ref": "#/components/schemas/Coordinate",
             "default": {
               "x": 0.0,
               "y": 0.0
@@ -178,198 +132,38 @@
         "title": "BoundingBox",
         "type": "object"
       },
-      "ConnectionContentItem": {
-        "$defs": {
-          "BoundingBox": {
-            "properties": {
-              "bottomRight": {
-                "$ref": "#/components/schemas/ConnectionContentItem/$defs/Coordinate",
-                "default": {
-                  "x": 0.0,
-                  "y": 0.0
-                }
-              },
-              "topLeft": {
-                "$ref": "#/components/schemas/ConnectionContentItem/$defs/Coordinate",
-                "default": {
-                  "x": 0.0,
-                  "y": 0.0
-                }
-              }
-            },
-            "type": "object"
+      "ChildrenStatus": {
+        "properties": {
+          "value": {
+            "$ref": "#/components/schemas/ChildrenStatusProfile"
           },
-          "ConnectionPrompt": {
-            "properties": {
-              "answer": {
-                "default": "",
-                "type": "string"
-              },
-              "contentId": {
-                "type": [
-                  "string",
-                  "null"
-                ]
-              },
-              "question": {
-                "default": "",
-                "type": "string"
-              }
-            },
-            "type": "object"
-          },
-          "ConnectionVideo": {
-            "properties": {
-              "boundingBox": {
-                "anyOf": [
-                  {
-                    "$ref": "#/components/schemas/ConnectionContentItem/$defs/BoundingBox"
-                  },
-                  {
-                    "type": "null"
-                  }
-                ]
-              },
-              "cdnId": {
-                "type": [
-                  "string",
-                  "null"
-                ]
-              },
-              "contentId": {
-                "type": [
-                  "string",
-                  "null"
-                ]
-              },
-              "thumbnail": {
-                "default": "",
-                "type": "string"
-              },
-              "url": {
-                "default": "",
-                "type": "string"
-              }
-            },
-            "type": "object"
-          },
-          "Coordinate": {
-            "properties": {
-              "x": {
-                "default": 0.0,
-                "format": "double",
-                "type": "number"
-              },
-              "y": {
-                "default": 0.0,
-                "format": "double",
-                "type": "number"
-              }
-            },
-            "type": "object"
-          },
-          "PhotoAsset": {
-            "properties": {
-              "boundingBox": {
-                "anyOf": [
-                  {
-                    "$ref": "#/components/schemas/ConnectionContentItem/$defs/BoundingBox"
-                  },
-                  {
-                    "type": "null"
-                  }
-                ]
-              },
-              "caption": {
-                "type": [
-                  "string",
-                  "null"
-                ]
-              },
-              "cdnId": {
-                "type": [
-                  "string",
-                  "null"
-                ]
-              },
-              "contentId": {
-                "type": [
-                  "string",
-                  "null"
-                ]
-              },
-              "height": {
-                "format": "int32",
-                "type": [
-                  "integer",
-                  "null"
-                ]
-              },
-              "id": {
-                "type": [
-                  "string",
-                  "null"
-                ]
-              },
-              "location": {
-                "type": [
-                  "string",
-                  "null"
-                ]
-              },
-              "pHash": {
-                "type": [
-                  "string",
-                  "null"
-                ]
-              },
-              "promptId": {
-                "type": [
-                  "string",
-                  "null"
-                ]
-              },
-              "selfieVerified": {
-                "type": [
-                  "boolean",
-                  "null"
-                ]
-              },
-              "source": {
-                "type": [
-                  "string",
-                  "null"
-                ]
-              },
-              "sourceId": {
-                "type": [
-                  "string",
-                  "null"
-                ]
-              },
-              "url": {
-                "type": "string"
-              },
-              "videoUrl": {
-                "type": [
-                  "string",
-                  "null"
-                ]
-              },
-              "width": {
-                "format": "int32",
-                "type": [
-                  "integer",
-                  "null"
-                ]
-              }
-            },
-            "required": [
-              "url"
-            ],
-            "type": "object"
+          "visible": {
+            "type": "boolean"
           }
         },
+        "required": [
+          "value",
+          "visible"
+        ],
+        "type": "object"
+      },
+      "ChildrenStatusPreference": {
+        "enum": [
+          "OpenToAll",
+          "No",
+          "Yes"
+        ],
+        "type": "string"
+      },
+      "ChildrenStatusProfile": {
+        "enum": [
+          "PreferNotToSay",
+          "No",
+          "Yes"
+        ],
+        "type": "string"
+      },
+      "ConnectionContentItem": {
         "properties": {
           "comment": {
             "type": [
@@ -380,7 +174,7 @@
           "photo": {
             "anyOf": [
               {
-                "$ref": "#/components/schemas/ConnectionContentItem/$defs/PhotoAsset"
+                "$ref": "#/components/schemas/PhotoAsset"
               },
               {
                 "type": "null"
@@ -390,7 +184,7 @@
           "prompt": {
             "anyOf": [
               {
-                "$ref": "#/components/schemas/ConnectionContentItem/$defs/ConnectionPrompt"
+                "$ref": "#/components/schemas/ConnectionPrompt"
               },
               {
                 "type": "null"
@@ -400,7 +194,7 @@
           "video": {
             "anyOf": [
               {
-                "$ref": "#/components/schemas/ConnectionContentItem/$defs/ConnectionVideo"
+                "$ref": "#/components/schemas/ConnectionVideo"
               },
               {
                 "type": "null"
@@ -412,238 +206,6 @@
         "type": "object"
       },
       "ConnectionDetailApi": {
-        "$defs": {
-          "BoundingBox": {
-            "properties": {
-              "bottomRight": {
-                "$ref": "#/components/schemas/ConnectionDetailApi/$defs/Coordinate",
-                "default": {
-                  "x": 0.0,
-                  "y": 0.0
-                }
-              },
-              "topLeft": {
-                "$ref": "#/components/schemas/ConnectionDetailApi/$defs/Coordinate",
-                "default": {
-                  "x": 0.0,
-                  "y": 0.0
-                }
-              }
-            },
-            "type": "object"
-          },
-          "ConnectionContentItem": {
-            "properties": {
-              "comment": {
-                "type": [
-                  "string",
-                  "null"
-                ]
-              },
-              "photo": {
-                "anyOf": [
-                  {
-                    "$ref": "#/components/schemas/ConnectionDetailApi/$defs/PhotoAsset"
-                  },
-                  {
-                    "type": "null"
-                  }
-                ]
-              },
-              "prompt": {
-                "anyOf": [
-                  {
-                    "$ref": "#/components/schemas/ConnectionDetailApi/$defs/ConnectionPrompt"
-                  },
-                  {
-                    "type": "null"
-                  }
-                ]
-              },
-              "video": {
-                "anyOf": [
-                  {
-                    "$ref": "#/components/schemas/ConnectionDetailApi/$defs/ConnectionVideo"
-                  },
-                  {
-                    "type": "null"
-                  }
-                ]
-              }
-            },
-            "type": "object"
-          },
-          "ConnectionPrompt": {
-            "properties": {
-              "answer": {
-                "default": "",
-                "type": "string"
-              },
-              "contentId": {
-                "type": [
-                  "string",
-                  "null"
-                ]
-              },
-              "question": {
-                "default": "",
-                "type": "string"
-              }
-            },
-            "type": "object"
-          },
-          "ConnectionVideo": {
-            "properties": {
-              "boundingBox": {
-                "anyOf": [
-                  {
-                    "$ref": "#/components/schemas/ConnectionDetailApi/$defs/BoundingBox"
-                  },
-                  {
-                    "type": "null"
-                  }
-                ]
-              },
-              "cdnId": {
-                "type": [
-                  "string",
-                  "null"
-                ]
-              },
-              "contentId": {
-                "type": [
-                  "string",
-                  "null"
-                ]
-              },
-              "thumbnail": {
-                "default": "",
-                "type": "string"
-              },
-              "url": {
-                "default": "",
-                "type": "string"
-              }
-            },
-            "type": "object"
-          },
-          "Coordinate": {
-            "properties": {
-              "x": {
-                "default": 0.0,
-                "format": "double",
-                "type": "number"
-              },
-              "y": {
-                "default": 0.0,
-                "format": "double",
-                "type": "number"
-              }
-            },
-            "type": "object"
-          },
-          "PhotoAsset": {
-            "properties": {
-              "boundingBox": {
-                "anyOf": [
-                  {
-                    "$ref": "#/components/schemas/ConnectionDetailApi/$defs/BoundingBox"
-                  },
-                  {
-                    "type": "null"
-                  }
-                ]
-              },
-              "caption": {
-                "type": [
-                  "string",
-                  "null"
-                ]
-              },
-              "cdnId": {
-                "type": [
-                  "string",
-                  "null"
-                ]
-              },
-              "contentId": {
-                "type": [
-                  "string",
-                  "null"
-                ]
-              },
-              "height": {
-                "format": "int32",
-                "type": [
-                  "integer",
-                  "null"
-                ]
-              },
-              "id": {
-                "type": [
-                  "string",
-                  "null"
-                ]
-              },
-              "location": {
-                "type": [
-                  "string",
-                  "null"
-                ]
-              },
-              "pHash": {
-                "type": [
-                  "string",
-                  "null"
-                ]
-              },
-              "promptId": {
-                "type": [
-                  "string",
-                  "null"
-                ]
-              },
-              "selfieVerified": {
-                "type": [
-                  "boolean",
-                  "null"
-                ]
-              },
-              "source": {
-                "type": [
-                  "string",
-                  "null"
-                ]
-              },
-              "sourceId": {
-                "type": [
-                  "string",
-                  "null"
-                ]
-              },
-              "url": {
-                "type": "string"
-              },
-              "videoUrl": {
-                "type": [
-                  "string",
-                  "null"
-                ]
-              },
-              "width": {
-                "format": "int32",
-                "type": [
-                  "integer",
-                  "null"
-                ]
-              }
-            },
-            "required": [
-              "url"
-            ],
-            "type": "object"
-          }
-        },
         "properties": {
           "initiatedWith": {
             "default": "",
@@ -666,7 +228,7 @@
           "sentContent": {
             "default": [],
             "items": {
-              "$ref": "#/components/schemas/ConnectionDetailApi/$defs/ConnectionContentItem"
+              "$ref": "#/components/schemas/ConnectionContentItem"
             },
             "type": "array"
           },
@@ -701,238 +263,6 @@
         "type": "object"
       },
       "ConnectionItem": {
-        "$defs": {
-          "BoundingBox": {
-            "properties": {
-              "bottomRight": {
-                "$ref": "#/components/schemas/ConnectionItem/$defs/Coordinate",
-                "default": {
-                  "x": 0.0,
-                  "y": 0.0
-                }
-              },
-              "topLeft": {
-                "$ref": "#/components/schemas/ConnectionItem/$defs/Coordinate",
-                "default": {
-                  "x": 0.0,
-                  "y": 0.0
-                }
-              }
-            },
-            "type": "object"
-          },
-          "ConnectionContentItem": {
-            "properties": {
-              "comment": {
-                "type": [
-                  "string",
-                  "null"
-                ]
-              },
-              "photo": {
-                "anyOf": [
-                  {
-                    "$ref": "#/components/schemas/ConnectionItem/$defs/PhotoAsset"
-                  },
-                  {
-                    "type": "null"
-                  }
-                ]
-              },
-              "prompt": {
-                "anyOf": [
-                  {
-                    "$ref": "#/components/schemas/ConnectionItem/$defs/ConnectionPrompt"
-                  },
-                  {
-                    "type": "null"
-                  }
-                ]
-              },
-              "video": {
-                "anyOf": [
-                  {
-                    "$ref": "#/components/schemas/ConnectionItem/$defs/ConnectionVideo"
-                  },
-                  {
-                    "type": "null"
-                  }
-                ]
-              }
-            },
-            "type": "object"
-          },
-          "ConnectionPrompt": {
-            "properties": {
-              "answer": {
-                "default": "",
-                "type": "string"
-              },
-              "contentId": {
-                "type": [
-                  "string",
-                  "null"
-                ]
-              },
-              "question": {
-                "default": "",
-                "type": "string"
-              }
-            },
-            "type": "object"
-          },
-          "ConnectionVideo": {
-            "properties": {
-              "boundingBox": {
-                "anyOf": [
-                  {
-                    "$ref": "#/components/schemas/ConnectionItem/$defs/BoundingBox"
-                  },
-                  {
-                    "type": "null"
-                  }
-                ]
-              },
-              "cdnId": {
-                "type": [
-                  "string",
-                  "null"
-                ]
-              },
-              "contentId": {
-                "type": [
-                  "string",
-                  "null"
-                ]
-              },
-              "thumbnail": {
-                "default": "",
-                "type": "string"
-              },
-              "url": {
-                "default": "",
-                "type": "string"
-              }
-            },
-            "type": "object"
-          },
-          "Coordinate": {
-            "properties": {
-              "x": {
-                "default": 0.0,
-                "format": "double",
-                "type": "number"
-              },
-              "y": {
-                "default": 0.0,
-                "format": "double",
-                "type": "number"
-              }
-            },
-            "type": "object"
-          },
-          "PhotoAsset": {
-            "properties": {
-              "boundingBox": {
-                "anyOf": [
-                  {
-                    "$ref": "#/components/schemas/ConnectionItem/$defs/BoundingBox"
-                  },
-                  {
-                    "type": "null"
-                  }
-                ]
-              },
-              "caption": {
-                "type": [
-                  "string",
-                  "null"
-                ]
-              },
-              "cdnId": {
-                "type": [
-                  "string",
-                  "null"
-                ]
-              },
-              "contentId": {
-                "type": [
-                  "string",
-                  "null"
-                ]
-              },
-              "height": {
-                "format": "int32",
-                "type": [
-                  "integer",
-                  "null"
-                ]
-              },
-              "id": {
-                "type": [
-                  "string",
-                  "null"
-                ]
-              },
-              "location": {
-                "type": [
-                  "string",
-                  "null"
-                ]
-              },
-              "pHash": {
-                "type": [
-                  "string",
-                  "null"
-                ]
-              },
-              "promptId": {
-                "type": [
-                  "string",
-                  "null"
-                ]
-              },
-              "selfieVerified": {
-                "type": [
-                  "boolean",
-                  "null"
-                ]
-              },
-              "source": {
-                "type": [
-                  "string",
-                  "null"
-                ]
-              },
-              "sourceId": {
-                "type": [
-                  "string",
-                  "null"
-                ]
-              },
-              "url": {
-                "type": "string"
-              },
-              "videoUrl": {
-                "type": [
-                  "string",
-                  "null"
-                ]
-              },
-              "width": {
-                "format": "int32",
-                "type": [
-                  "integer",
-                  "null"
-                ]
-              }
-            },
-            "required": [
-              "url"
-            ],
-            "type": "object"
-          }
-        },
         "properties": {
           "initiatedWith": {
             "default": "",
@@ -955,7 +285,7 @@
           "sentContent": {
             "default": [],
             "items": {
-              "$ref": "#/components/schemas/ConnectionItem/$defs/ConnectionContentItem"
+              "$ref": "#/components/schemas/ConnectionContentItem"
             },
             "type": "array"
           },
@@ -1004,47 +334,11 @@
         "type": "object"
       },
       "ConnectionVideo": {
-        "$defs": {
-          "BoundingBox": {
-            "properties": {
-              "bottomRight": {
-                "$ref": "#/components/schemas/ConnectionVideo/$defs/Coordinate",
-                "default": {
-                  "x": 0.0,
-                  "y": 0.0
-                }
-              },
-              "topLeft": {
-                "$ref": "#/components/schemas/ConnectionVideo/$defs/Coordinate",
-                "default": {
-                  "x": 0.0,
-                  "y": 0.0
-                }
-              }
-            },
-            "type": "object"
-          },
-          "Coordinate": {
-            "properties": {
-              "x": {
-                "default": 0.0,
-                "format": "double",
-                "type": "number"
-              },
-              "y": {
-                "default": 0.0,
-                "format": "double",
-                "type": "number"
-              }
-            },
-            "type": "object"
-          }
-        },
         "properties": {
           "boundingBox": {
             "anyOf": [
               {
-                "$ref": "#/components/schemas/ConnectionVideo/$defs/BoundingBox"
+                "$ref": "#/components/schemas/BoundingBox"
               },
               {
                 "type": "null"
@@ -1076,293 +370,11 @@
         "type": "object"
       },
       "ConnectionsResponse": {
-        "$defs": {
-          "BoundingBox": {
-            "properties": {
-              "bottomRight": {
-                "$ref": "#/components/schemas/ConnectionsResponse/$defs/Coordinate",
-                "default": {
-                  "x": 0.0,
-                  "y": 0.0
-                }
-              },
-              "topLeft": {
-                "$ref": "#/components/schemas/ConnectionsResponse/$defs/Coordinate",
-                "default": {
-                  "x": 0.0,
-                  "y": 0.0
-                }
-              }
-            },
-            "type": "object"
-          },
-          "ConnectionContentItem": {
-            "properties": {
-              "comment": {
-                "type": [
-                  "string",
-                  "null"
-                ]
-              },
-              "photo": {
-                "anyOf": [
-                  {
-                    "$ref": "#/components/schemas/ConnectionsResponse/$defs/PhotoAsset"
-                  },
-                  {
-                    "type": "null"
-                  }
-                ]
-              },
-              "prompt": {
-                "anyOf": [
-                  {
-                    "$ref": "#/components/schemas/ConnectionsResponse/$defs/ConnectionPrompt"
-                  },
-                  {
-                    "type": "null"
-                  }
-                ]
-              },
-              "video": {
-                "anyOf": [
-                  {
-                    "$ref": "#/components/schemas/ConnectionsResponse/$defs/ConnectionVideo"
-                  },
-                  {
-                    "type": "null"
-                  }
-                ]
-              }
-            },
-            "type": "object"
-          },
-          "ConnectionItem": {
-            "properties": {
-              "initiatedWith": {
-                "default": "",
-                "type": "string"
-              },
-              "initiatorId": {
-                "default": "",
-                "type": "string"
-              },
-              "isHidden": {
-                "default": false,
-                "type": "boolean"
-              },
-              "receivedTime": {
-                "type": [
-                  "string",
-                  "null"
-                ]
-              },
-              "sentContent": {
-                "default": [],
-                "items": {
-                  "$ref": "#/components/schemas/ConnectionsResponse/$defs/ConnectionContentItem"
-                },
-                "type": "array"
-              },
-              "sentTime": {
-                "type": [
-                  "string",
-                  "null"
-                ]
-              },
-              "socialMediaExchangedTimestamp": {
-                "type": [
-                  "string",
-                  "null"
-                ]
-              },
-              "source": {
-                "default": "",
-                "type": "string"
-              },
-              "subjectId": {
-                "default": "",
-                "type": "string"
-              }
-            },
-            "type": "object"
-          },
-          "ConnectionPrompt": {
-            "properties": {
-              "answer": {
-                "default": "",
-                "type": "string"
-              },
-              "contentId": {
-                "type": [
-                  "string",
-                  "null"
-                ]
-              },
-              "question": {
-                "default": "",
-                "type": "string"
-              }
-            },
-            "type": "object"
-          },
-          "ConnectionVideo": {
-            "properties": {
-              "boundingBox": {
-                "anyOf": [
-                  {
-                    "$ref": "#/components/schemas/ConnectionsResponse/$defs/BoundingBox"
-                  },
-                  {
-                    "type": "null"
-                  }
-                ]
-              },
-              "cdnId": {
-                "type": [
-                  "string",
-                  "null"
-                ]
-              },
-              "contentId": {
-                "type": [
-                  "string",
-                  "null"
-                ]
-              },
-              "thumbnail": {
-                "default": "",
-                "type": "string"
-              },
-              "url": {
-                "default": "",
-                "type": "string"
-              }
-            },
-            "type": "object"
-          },
-          "Coordinate": {
-            "properties": {
-              "x": {
-                "default": 0.0,
-                "format": "double",
-                "type": "number"
-              },
-              "y": {
-                "default": 0.0,
-                "format": "double",
-                "type": "number"
-              }
-            },
-            "type": "object"
-          },
-          "PhotoAsset": {
-            "properties": {
-              "boundingBox": {
-                "anyOf": [
-                  {
-                    "$ref": "#/components/schemas/ConnectionsResponse/$defs/BoundingBox"
-                  },
-                  {
-                    "type": "null"
-                  }
-                ]
-              },
-              "caption": {
-                "type": [
-                  "string",
-                  "null"
-                ]
-              },
-              "cdnId": {
-                "type": [
-                  "string",
-                  "null"
-                ]
-              },
-              "contentId": {
-                "type": [
-                  "string",
-                  "null"
-                ]
-              },
-              "height": {
-                "format": "int32",
-                "type": [
-                  "integer",
-                  "null"
-                ]
-              },
-              "id": {
-                "type": [
-                  "string",
-                  "null"
-                ]
-              },
-              "location": {
-                "type": [
-                  "string",
-                  "null"
-                ]
-              },
-              "pHash": {
-                "type": [
-                  "string",
-                  "null"
-                ]
-              },
-              "promptId": {
-                "type": [
-                  "string",
-                  "null"
-                ]
-              },
-              "selfieVerified": {
-                "type": [
-                  "boolean",
-                  "null"
-                ]
-              },
-              "source": {
-                "type": [
-                  "string",
-                  "null"
-                ]
-              },
-              "sourceId": {
-                "type": [
-                  "string",
-                  "null"
-                ]
-              },
-              "url": {
-                "type": "string"
-              },
-              "videoUrl": {
-                "type": [
-                  "string",
-                  "null"
-                ]
-              },
-              "width": {
-                "format": "int32",
-                "type": [
-                  "integer",
-                  "null"
-                ]
-              }
-            },
-            "required": [
-              "url"
-            ],
-            "type": "object"
-          }
-        },
         "properties": {
           "connections": {
             "default": [],
             "items": {
-              "$ref": "#/components/schemas/ConnectionsResponse/$defs/ConnectionItem"
+              "$ref": "#/components/schemas/ConnectionItem"
             },
             "type": "array"
           },
@@ -1376,317 +388,25 @@
         "type": "object"
       },
       "ContentData": {
-        "$defs": {
-          "BoundingBox": {
-            "properties": {
-              "bottomRight": {
-                "$ref": "#/components/schemas/ContentData/$defs/Coordinate",
-                "default": {
-                  "x": 0.0,
-                  "y": 0.0
-                }
-              },
-              "topLeft": {
-                "$ref": "#/components/schemas/ContentData/$defs/Coordinate",
-                "default": {
-                  "x": 0.0,
-                  "y": 0.0
-                }
-              }
-            },
-            "type": "object"
-          },
-          "Coordinate": {
-            "properties": {
-              "x": {
-                "default": 0.0,
-                "format": "double",
-                "type": "number"
-              },
-              "y": {
-                "default": 0.0,
-                "format": "double",
-                "type": "number"
-              }
-            },
-            "type": "object"
-          },
-          "Feedback": {
-            "properties": {
-              "detail": {
-                "type": "string"
-              },
-              "evaluation": {
-                "type": "string"
-              },
-              "feedbackToken": {
-                "type": "string"
-              }
-            },
-            "required": [
-              "evaluation",
-              "detail",
-              "feedbackToken"
-            ],
-            "type": "object"
-          },
-          "PhotoAsset": {
-            "properties": {
-              "boundingBox": {
-                "anyOf": [
-                  {
-                    "$ref": "#/components/schemas/ContentData/$defs/BoundingBox"
-                  },
-                  {
-                    "type": "null"
-                  }
-                ]
-              },
-              "caption": {
-                "type": [
-                  "string",
-                  "null"
-                ]
-              },
-              "cdnId": {
-                "type": [
-                  "string",
-                  "null"
-                ]
-              },
-              "contentId": {
-                "type": [
-                  "string",
-                  "null"
-                ]
-              },
-              "height": {
-                "format": "int32",
-                "type": [
-                  "integer",
-                  "null"
-                ]
-              },
-              "id": {
-                "type": [
-                  "string",
-                  "null"
-                ]
-              },
-              "location": {
-                "type": [
-                  "string",
-                  "null"
-                ]
-              },
-              "pHash": {
-                "type": [
-                  "string",
-                  "null"
-                ]
-              },
-              "promptId": {
-                "type": [
-                  "string",
-                  "null"
-                ]
-              },
-              "selfieVerified": {
-                "type": [
-                  "boolean",
-                  "null"
-                ]
-              },
-              "source": {
-                "type": [
-                  "string",
-                  "null"
-                ]
-              },
-              "sourceId": {
-                "type": [
-                  "string",
-                  "null"
-                ]
-              },
-              "url": {
-                "type": "string"
-              },
-              "videoUrl": {
-                "type": [
-                  "string",
-                  "null"
-                ]
-              },
-              "width": {
-                "format": "int32",
-                "type": [
-                  "integer",
-                  "null"
-                ]
-              }
-            },
-            "required": [
-              "url"
-            ],
-            "type": "object"
-          },
-          "ProfileAnswer": {
-            "properties": {
-              "cdnId": {
-                "type": [
-                  "string",
-                  "null"
-                ]
-              },
-              "content": {
-                "type": [
-                  "string",
-                  "null"
-                ]
-              },
-              "contentId": {
-                "type": [
-                  "string",
-                  "null"
-                ]
-              },
-              "feedback": {
-                "anyOf": [
-                  {
-                    "$ref": "#/components/schemas/ContentData/$defs/Feedback"
-                  },
-                  {
-                    "type": "null"
-                  }
-                ]
-              },
-              "position": {
-                "format": "int32",
-                "type": [
-                  "integer",
-                  "null"
-                ]
-              },
-              "promptId": {
-                "type": [
-                  "string",
-                  "null"
-                ]
-              },
-              "questionId": {
-                "type": [
-                  "string",
-                  "null"
-                ]
-              },
-              "response": {
-                "type": [
-                  "string",
-                  "null"
-                ]
-              },
-              "transcription": {
-                "type": [
-                  "string",
-                  "null"
-                ]
-              },
-              "transcriptionMetadata": true,
-              "type": {
-                "type": [
-                  "string",
-                  "null"
-                ]
-              },
-              "url": {
-                "type": [
-                  "string",
-                  "null"
-                ]
-              },
-              "waveform": {
-                "type": [
-                  "string",
-                  "null"
-                ]
-              }
-            },
-            "type": "object"
-          },
-          "PromptPoll": {
-            "properties": {
-              "contentId": {
-                "type": "string"
-              },
-              "options": {
-                "items": {
-                  "type": "string"
-                },
-                "type": "array"
-              },
-              "questionId": {
-                "type": "string"
-              }
-            },
-            "required": [
-              "contentId",
-              "questionId",
-              "options"
-            ],
-            "type": "object"
-          },
-          "VideoPrompt": {
-            "properties": {
-              "boundingBox": {
-                "$ref": "#/components/schemas/ContentData/$defs/BoundingBox"
-              },
-              "cdnId": {
-                "type": "string"
-              },
-              "contentId": {
-                "type": "string"
-              },
-              "questionId": {
-                "type": "string"
-              },
-              "thumbnailUrl": {
-                "type": "string"
-              },
-              "videoUrl": {
-                "type": "string"
-              }
-            },
-            "required": [
-              "contentId",
-              "questionId",
-              "thumbnailUrl",
-              "videoUrl",
-              "cdnId",
-              "boundingBox"
-            ],
-            "type": "object"
-          }
-        },
         "properties": {
           "answers": {
             "default": [],
             "items": {
-              "$ref": "#/components/schemas/ContentData/$defs/ProfileAnswer"
+              "$ref": "#/components/schemas/ProfileAnswer"
             },
             "type": "array"
           },
           "photos": {
             "default": [],
             "items": {
-              "$ref": "#/components/schemas/ContentData/$defs/PhotoAsset"
+              "$ref": "#/components/schemas/PhotoAsset"
             },
             "type": "array"
           },
           "promptPoll": {
             "anyOf": [
               {
-                "$ref": "#/components/schemas/ContentData/$defs/PromptPoll"
+                "$ref": "#/components/schemas/PromptPoll"
               },
               {
                 "type": "null"
@@ -1696,7 +416,7 @@
           "videoPrompt": {
             "anyOf": [
               {
-                "$ref": "#/components/schemas/ContentData/$defs/VideoPrompt"
+                "$ref": "#/components/schemas/VideoPrompt"
               },
               {
                 "type": "null"
@@ -1705,6 +425,32 @@
           }
         },
         "title": "ContentData",
+        "type": "object"
+      },
+      "ContentType": {
+        "enum": [
+          "text",
+          "media",
+          "audio",
+          "video",
+          "voice",
+          "poll"
+        ],
+        "type": "string"
+      },
+      "Coordinate": {
+        "properties": {
+          "x": {
+            "default": 0.0,
+            "format": "double",
+            "type": "number"
+          },
+          "y": {
+            "default": 0.0,
+            "format": "double",
+            "type": "number"
+          }
+        },
         "type": "object"
       },
       "CreatePromptPollRequest": {
@@ -1739,200 +485,11 @@
         "type": "object"
       },
       "CreateRate": {
-        "$defs": {
-          "BoundingBox": {
-            "properties": {
-              "bottomRight": {
-                "$ref": "#/components/schemas/CreateRate/$defs/Coordinate",
-                "default": {
-                  "x": 0.0,
-                  "y": 0.0
-                }
-              },
-              "topLeft": {
-                "$ref": "#/components/schemas/CreateRate/$defs/Coordinate",
-                "default": {
-                  "x": 0.0,
-                  "y": 0.0
-                }
-              }
-            },
-            "type": "object"
-          },
-          "Coordinate": {
-            "properties": {
-              "x": {
-                "default": 0.0,
-                "format": "double",
-                "type": "number"
-              },
-              "y": {
-                "default": 0.0,
-                "format": "double",
-                "type": "number"
-              }
-            },
-            "type": "object"
-          },
-          "CreateRateContent": {
-            "properties": {
-              "comment": {
-                "type": [
-                  "string",
-                  "null"
-                ]
-              },
-              "photo": {
-                "anyOf": [
-                  {
-                    "$ref": "#/components/schemas/CreateRate/$defs/PhotoAsset"
-                  },
-                  {
-                    "type": "null"
-                  }
-                ]
-              },
-              "prompt": {
-                "anyOf": [
-                  {
-                    "$ref": "#/components/schemas/CreateRate/$defs/CreateRateContentPrompt"
-                  },
-                  {
-                    "type": "null"
-                  }
-                ]
-              }
-            },
-            "type": "object"
-          },
-          "CreateRateContentPrompt": {
-            "properties": {
-              "answer": {
-                "type": "string"
-              },
-              "contentId": {
-                "type": [
-                  "string",
-                  "null"
-                ]
-              },
-              "question": {
-                "type": "string"
-              }
-            },
-            "required": [
-              "answer",
-              "question"
-            ],
-            "type": "object"
-          },
-          "PhotoAsset": {
-            "properties": {
-              "boundingBox": {
-                "anyOf": [
-                  {
-                    "$ref": "#/components/schemas/CreateRate/$defs/BoundingBox"
-                  },
-                  {
-                    "type": "null"
-                  }
-                ]
-              },
-              "caption": {
-                "type": [
-                  "string",
-                  "null"
-                ]
-              },
-              "cdnId": {
-                "type": [
-                  "string",
-                  "null"
-                ]
-              },
-              "contentId": {
-                "type": [
-                  "string",
-                  "null"
-                ]
-              },
-              "height": {
-                "format": "int32",
-                "type": [
-                  "integer",
-                  "null"
-                ]
-              },
-              "id": {
-                "type": [
-                  "string",
-                  "null"
-                ]
-              },
-              "location": {
-                "type": [
-                  "string",
-                  "null"
-                ]
-              },
-              "pHash": {
-                "type": [
-                  "string",
-                  "null"
-                ]
-              },
-              "promptId": {
-                "type": [
-                  "string",
-                  "null"
-                ]
-              },
-              "selfieVerified": {
-                "type": [
-                  "boolean",
-                  "null"
-                ]
-              },
-              "source": {
-                "type": [
-                  "string",
-                  "null"
-                ]
-              },
-              "sourceId": {
-                "type": [
-                  "string",
-                  "null"
-                ]
-              },
-              "url": {
-                "type": "string"
-              },
-              "videoUrl": {
-                "type": [
-                  "string",
-                  "null"
-                ]
-              },
-              "width": {
-                "format": "int32",
-                "type": [
-                  "integer",
-                  "null"
-                ]
-              }
-            },
-            "required": [
-              "url"
-            ],
-            "type": "object"
-          }
-        },
         "properties": {
           "content": {
             "anyOf": [
               {
-                "$ref": "#/components/schemas/CreateRate/$defs/CreateRateContent"
+                "$ref": "#/components/schemas/CreateRateContent"
               },
               {
                 "type": "null"
@@ -1992,164 +549,6 @@
         "type": "object"
       },
       "CreateRateContent": {
-        "$defs": {
-          "BoundingBox": {
-            "properties": {
-              "bottomRight": {
-                "$ref": "#/components/schemas/CreateRateContent/$defs/Coordinate",
-                "default": {
-                  "x": 0.0,
-                  "y": 0.0
-                }
-              },
-              "topLeft": {
-                "$ref": "#/components/schemas/CreateRateContent/$defs/Coordinate",
-                "default": {
-                  "x": 0.0,
-                  "y": 0.0
-                }
-              }
-            },
-            "type": "object"
-          },
-          "Coordinate": {
-            "properties": {
-              "x": {
-                "default": 0.0,
-                "format": "double",
-                "type": "number"
-              },
-              "y": {
-                "default": 0.0,
-                "format": "double",
-                "type": "number"
-              }
-            },
-            "type": "object"
-          },
-          "CreateRateContentPrompt": {
-            "properties": {
-              "answer": {
-                "type": "string"
-              },
-              "contentId": {
-                "type": [
-                  "string",
-                  "null"
-                ]
-              },
-              "question": {
-                "type": "string"
-              }
-            },
-            "required": [
-              "answer",
-              "question"
-            ],
-            "type": "object"
-          },
-          "PhotoAsset": {
-            "properties": {
-              "boundingBox": {
-                "anyOf": [
-                  {
-                    "$ref": "#/components/schemas/CreateRateContent/$defs/BoundingBox"
-                  },
-                  {
-                    "type": "null"
-                  }
-                ]
-              },
-              "caption": {
-                "type": [
-                  "string",
-                  "null"
-                ]
-              },
-              "cdnId": {
-                "type": [
-                  "string",
-                  "null"
-                ]
-              },
-              "contentId": {
-                "type": [
-                  "string",
-                  "null"
-                ]
-              },
-              "height": {
-                "format": "int32",
-                "type": [
-                  "integer",
-                  "null"
-                ]
-              },
-              "id": {
-                "type": [
-                  "string",
-                  "null"
-                ]
-              },
-              "location": {
-                "type": [
-                  "string",
-                  "null"
-                ]
-              },
-              "pHash": {
-                "type": [
-                  "string",
-                  "null"
-                ]
-              },
-              "promptId": {
-                "type": [
-                  "string",
-                  "null"
-                ]
-              },
-              "selfieVerified": {
-                "type": [
-                  "boolean",
-                  "null"
-                ]
-              },
-              "source": {
-                "type": [
-                  "string",
-                  "null"
-                ]
-              },
-              "sourceId": {
-                "type": [
-                  "string",
-                  "null"
-                ]
-              },
-              "url": {
-                "type": "string"
-              },
-              "videoUrl": {
-                "type": [
-                  "string",
-                  "null"
-                ]
-              },
-              "width": {
-                "format": "int32",
-                "type": [
-                  "integer",
-                  "null"
-                ]
-              }
-            },
-            "required": [
-              "url"
-            ],
-            "type": "object"
-          }
-        },
         "properties": {
           "comment": {
             "type": [
@@ -2160,7 +559,7 @@
           "photo": {
             "anyOf": [
               {
-                "$ref": "#/components/schemas/CreateRateContent/$defs/PhotoAsset"
+                "$ref": "#/components/schemas/PhotoAsset"
               },
               {
                 "type": "null"
@@ -2170,7 +569,7 @@
           "prompt": {
             "anyOf": [
               {
-                "$ref": "#/components/schemas/CreateRateContent/$defs/CreateRateContentPrompt"
+                "$ref": "#/components/schemas/CreateRateContentPrompt"
               },
               {
                 "type": "null"
@@ -2204,45 +603,9 @@
         "type": "object"
       },
       "CreateVideoPromptRequest": {
-        "$defs": {
-          "BoundingBox": {
-            "properties": {
-              "bottomRight": {
-                "$ref": "#/components/schemas/CreateVideoPromptRequest/$defs/Coordinate",
-                "default": {
-                  "x": 0.0,
-                  "y": 0.0
-                }
-              },
-              "topLeft": {
-                "$ref": "#/components/schemas/CreateVideoPromptRequest/$defs/Coordinate",
-                "default": {
-                  "x": 0.0,
-                  "y": 0.0
-                }
-              }
-            },
-            "type": "object"
-          },
-          "Coordinate": {
-            "properties": {
-              "x": {
-                "default": 0.0,
-                "format": "double",
-                "type": "number"
-              },
-              "y": {
-                "default": 0.0,
-                "format": "double",
-                "type": "number"
-              }
-            },
-            "type": "object"
-          }
-        },
         "properties": {
           "boundingBox": {
-            "$ref": "#/components/schemas/CreateVideoPromptRequest/$defs/BoundingBox"
+            "$ref": "#/components/schemas/BoundingBox"
           },
           "cdnId": {
             "type": "string"
@@ -2288,32 +651,46 @@
         "title": "CreateVideoPromptResponse",
         "type": "object"
       },
-      "Dealbreakers": {
-        "$defs": {
-          "GenderedDealbreaker": {
-            "properties": {
-              "0": {
-                "type": [
-                  "boolean",
-                  "null"
-                ]
-              },
-              "1": {
-                "type": [
-                  "boolean",
-                  "null"
-                ]
-              },
-              "3": {
-                "type": [
-                  "boolean",
-                  "null"
-                ]
-              }
-            },
-            "type": "object"
+      "DatingIntention": {
+        "properties": {
+          "value": {
+            "$ref": "#/components/schemas/DatingIntentionProfile"
+          },
+          "visible": {
+            "type": "boolean"
           }
         },
+        "required": [
+          "value",
+          "visible"
+        ],
+        "type": "object"
+      },
+      "DatingIntentionPreference": {
+        "enum": [
+          "OpenToAll",
+          "LifePartner",
+          "LongTermRelationship",
+          "LongTermOpenToShort",
+          "ShortTermOpenToLong",
+          "ShortTermRelationship",
+          "FiguringOutTheirDatingGoals"
+        ],
+        "type": "string"
+      },
+      "DatingIntentionProfile": {
+        "enum": [
+          "PreferNotToSay",
+          "LifePartner",
+          "LongTermRelationship",
+          "LongTermOpenToShort",
+          "ShortTermOpenToLong",
+          "ShortTermRelationship",
+          "FiguringOutTheirDatingGoals"
+        ],
+        "type": "string"
+      },
+      "Dealbreakers": {
         "properties": {
           "children": {
             "type": "boolean"
@@ -2337,10 +714,10 @@
             "type": "boolean"
           },
           "genderedAge": {
-            "$ref": "#/components/schemas/Dealbreakers/$defs/GenderedDealbreaker"
+            "$ref": "#/components/schemas/GenderedDealbreaker"
           },
           "genderedHeight": {
-            "$ref": "#/components/schemas/Dealbreakers/$defs/GenderedDealbreaker"
+            "$ref": "#/components/schemas/GenderedDealbreaker"
           },
           "marijuana": {
             "type": "boolean"
@@ -2381,6 +758,114 @@
         "title": "Dealbreakers",
         "type": "object"
       },
+      "DrinkingStatus": {
+        "properties": {
+          "value": {
+            "$ref": "#/components/schemas/DrinkingStatusProfile"
+          },
+          "visible": {
+            "type": "boolean"
+          }
+        },
+        "required": [
+          "value",
+          "visible"
+        ],
+        "type": "object"
+      },
+      "DrinkingStatusPreference": {
+        "enum": [
+          "OpenToAll",
+          "No",
+          "Yes",
+          "Sometimes"
+        ],
+        "type": "string"
+      },
+      "DrinkingStatusProfile": {
+        "enum": [
+          "PreferNotToSay",
+          "No",
+          "Yes",
+          "Sometimes"
+        ],
+        "type": "string"
+      },
+      "DrugStatus": {
+        "properties": {
+          "value": {
+            "$ref": "#/components/schemas/DrugStatusProfile"
+          },
+          "visible": {
+            "type": "boolean"
+          }
+        },
+        "required": [
+          "value",
+          "visible"
+        ],
+        "type": "object"
+      },
+      "DrugStatusPreference": {
+        "enum": [
+          "OpenToAll",
+          "No",
+          "Yes",
+          "Sometimes"
+        ],
+        "type": "string"
+      },
+      "DrugStatusProfile": {
+        "enum": [
+          "PreferNotToSay",
+          "No",
+          "Yes",
+          "Sometimes"
+        ],
+        "type": "string"
+      },
+      "EducationAttainedPreference": {
+        "enum": [
+          "OpenToAll",
+          "HighSchool",
+          "TradeSchool",
+          "InCollege",
+          "Undergraduate",
+          "InGradSchool",
+          "Graduate"
+        ],
+        "type": "string"
+      },
+      "EducationAttainedProfile": {
+        "enum": [
+          "PreferNotToSay",
+          "HighSchool",
+          "TradeSchool",
+          "InCollege",
+          "Undergraduate",
+          "InGradSchool",
+          "Graduate"
+        ],
+        "type": "string"
+      },
+      "Educations": {
+        "properties": {
+          "value": {
+            "items": {
+              "type": "string"
+            },
+            "type": "array"
+          },
+          "visible": {
+            "type": "boolean"
+          }
+        },
+        "required": [
+          "value",
+          "visible"
+        ],
+        "type": "object"
+      },
       "EmailCodeRequest": {
         "additionalProperties": true,
         "properties": {
@@ -2413,6 +898,54 @@
         },
         "type": "object"
       },
+      "Ethnicities": {
+        "properties": {
+          "value": {
+            "items": {
+              "$ref": "#/components/schemas/EthnicityProfile"
+            },
+            "type": "array"
+          },
+          "visible": {
+            "type": "boolean"
+          }
+        },
+        "required": [
+          "value",
+          "visible"
+        ],
+        "type": "object"
+      },
+      "EthnicityPreference": {
+        "enum": [
+          "OpenToAll",
+          "AmericanIndian",
+          "BlackAfrican",
+          "EastAsian",
+          "Hispanic",
+          "MiddleEastern",
+          "PacificIslander",
+          "SouthAsian",
+          "White",
+          "Other"
+        ],
+        "type": "string"
+      },
+      "EthnicityProfile": {
+        "enum": [
+          "PreferNotToSay",
+          "AmericanIndian",
+          "BlackAfrican",
+          "EastAsian",
+          "Hispanic",
+          "MiddleEastern",
+          "PacificIslander",
+          "SouthAsian",
+          "White",
+          "Other"
+        ],
+        "type": "string"
+      },
       "ExportChatInput": {
         "properties": {
           "channelUrl": {
@@ -2443,34 +976,13 @@
         "type": "object"
       },
       "ExportChatResult": {
-        "$defs": {
-          "ExportedMediaFile": {
-            "properties": {
-              "fileName": {
-                "type": "string"
-              },
-              "filePath": {
-                "type": "string"
-              },
-              "messageId": {
-                "type": "string"
-              }
-            },
-            "required": [
-              "messageId",
-              "fileName",
-              "filePath"
-            ],
-            "type": "object"
-          }
-        },
         "properties": {
           "folderPath": {
             "type": "string"
           },
           "mediaFiles": {
             "items": {
-              "$ref": "#/components/schemas/ExportChatResult/$defs/ExportedMediaFile"
+              "$ref": "#/components/schemas/ExportedMediaFile"
             },
             "type": "array"
           },
@@ -2542,6 +1054,22 @@
         "title": "ExportedMediaFile",
         "type": "object"
       },
+      "FamilyPlans": {
+        "properties": {
+          "value": {
+            "format": "int32",
+            "type": "integer"
+          },
+          "visible": {
+            "type": "boolean"
+          }
+        },
+        "required": [
+          "value",
+          "visible"
+        ],
+        "type": "object"
+      },
       "Feedback": {
         "properties": {
           "detail": {
@@ -2561,6 +1089,38 @@
         ],
         "title": "Feedback",
         "type": "object"
+      },
+      "GenderEnum": {
+        "enum": [
+          "Man",
+          "Woman",
+          "NonBinary"
+        ],
+        "type": "string"
+      },
+      "GenderIdentityId": {
+        "properties": {
+          "value": {
+            "format": "int32",
+            "type": "integer"
+          },
+          "visible": {
+            "type": "boolean"
+          }
+        },
+        "required": [
+          "value",
+          "visible"
+        ],
+        "type": "object"
+      },
+      "GenderPreferences": {
+        "enum": [
+          "Men",
+          "Women",
+          "Everyone"
+        ],
+        "type": "string"
       },
       "GenderedDealbreaker": {
         "properties": {
@@ -2587,32 +1147,11 @@
         "type": "object"
       },
       "GenderedRange": {
-        "$defs": {
-          "RangeDetails": {
-            "properties": {
-              "max": {
-                "format": "int32",
-                "type": [
-                  "integer",
-                  "null"
-                ]
-              },
-              "min": {
-                "format": "int32",
-                "type": [
-                  "integer",
-                  "null"
-                ]
-              }
-            },
-            "type": "object"
-          }
-        },
         "properties": {
           "0": {
             "anyOf": [
               {
-                "$ref": "#/components/schemas/GenderedRange/$defs/RangeDetails"
+                "$ref": "#/components/schemas/RangeDetails"
               },
               {
                 "type": "null"
@@ -2622,7 +1161,7 @@
           "1": {
             "anyOf": [
               {
-                "$ref": "#/components/schemas/GenderedRange/$defs/RangeDetails"
+                "$ref": "#/components/schemas/RangeDetails"
               },
               {
                 "type": "null"
@@ -2632,7 +1171,7 @@
           "3": {
             "anyOf": [
               {
-                "$ref": "#/components/schemas/GenderedRange/$defs/RangeDetails"
+                "$ref": "#/components/schemas/RangeDetails"
               },
               {
                 "type": "null"
@@ -2664,6 +1203,21 @@
         "title": "HingeAuthToken",
         "type": "object"
       },
+      "Hometown": {
+        "properties": {
+          "value": {
+            "type": "string"
+          },
+          "visible": {
+            "type": "boolean"
+          }
+        },
+        "required": [
+          "value",
+          "visible"
+        ],
+        "type": "object"
+      },
       "InstallRequest": {
         "additionalProperties": true,
         "properties": {
@@ -2673,259 +1227,41 @@
         },
         "type": "object"
       },
-      "LikeItemV2": {
-        "$defs": {
-          "BoundingBox": {
-            "properties": {
-              "bottomRight": {
-                "$ref": "#/components/schemas/LikeItemV2/$defs/Coordinate",
-                "default": {
-                  "x": 0.0,
-                  "y": 0.0
-                }
-              },
-              "topLeft": {
-                "$ref": "#/components/schemas/LikeItemV2/$defs/Coordinate",
-                "default": {
-                  "x": 0.0,
-                  "y": 0.0
-                }
-              }
-            },
-            "type": "object"
+      "JobTitle": {
+        "properties": {
+          "value": {
+            "type": "string"
           },
-          "Coordinate": {
-            "properties": {
-              "x": {
-                "default": 0.0,
-                "format": "double",
-                "type": "number"
-              },
-              "y": {
-                "default": 0.0,
-                "format": "double",
-                "type": "number"
-              }
-            },
-            "type": "object"
-          },
-          "CreateRateContentPrompt": {
-            "properties": {
-              "answer": {
-                "type": "string"
-              },
-              "contentId": {
-                "type": [
-                  "string",
-                  "null"
-                ]
-              },
-              "question": {
-                "type": "string"
-              }
-            },
-            "required": [
-              "answer",
-              "question"
-            ],
-            "type": "object"
-          },
-          "LikePromptPoll": {
-            "properties": {
-              "contentId": {
-                "type": [
-                  "string",
-                  "null"
-                ]
-              },
-              "options": {
-                "items": {
-                  "type": "string"
-                },
-                "type": "array"
-              },
-              "questionId": {
-                "type": "string"
-              },
-              "selectedOption": {
-                "type": [
-                  "string",
-                  "null"
-                ]
-              },
-              "selectedOptionIndex": {
-                "format": "int32",
-                "type": [
-                  "integer",
-                  "null"
-                ]
-              }
-            },
-            "required": [
-              "options",
-              "questionId"
-            ],
-            "type": "object"
-          },
-          "LikeRating": {
-            "properties": {
-              "content": {
-                "default": [],
-                "items": {
-                  "$ref": "#/components/schemas/LikeItemV2/$defs/LikeRatingContentItem"
-                },
-                "type": "array"
-              }
-            },
-            "type": "object"
-          },
-          "LikeRatingContentItem": {
-            "properties": {
-              "comment": {
-                "default": null,
-                "type": [
-                  "string",
-                  "null"
-                ]
-              },
-              "photo": {
-                "anyOf": [
-                  {
-                    "$ref": "#/components/schemas/LikeItemV2/$defs/PhotoAsset"
-                  },
-                  {
-                    "type": "null"
-                  }
-                ],
-                "default": null
-              },
-              "prompt": {
-                "anyOf": [
-                  {
-                    "$ref": "#/components/schemas/LikeItemV2/$defs/CreateRateContentPrompt"
-                  },
-                  {
-                    "type": "null"
-                  }
-                ],
-                "default": null
-              },
-              "promptPoll": {
-                "anyOf": [
-                  {
-                    "$ref": "#/components/schemas/LikeItemV2/$defs/LikePromptPoll"
-                  },
-                  {
-                    "type": "null"
-                  }
-                ],
-                "default": null
-              }
-            },
-            "type": "object"
-          },
-          "PhotoAsset": {
-            "properties": {
-              "boundingBox": {
-                "anyOf": [
-                  {
-                    "$ref": "#/components/schemas/LikeItemV2/$defs/BoundingBox"
-                  },
-                  {
-                    "type": "null"
-                  }
-                ]
-              },
-              "caption": {
-                "type": [
-                  "string",
-                  "null"
-                ]
-              },
-              "cdnId": {
-                "type": [
-                  "string",
-                  "null"
-                ]
-              },
-              "contentId": {
-                "type": [
-                  "string",
-                  "null"
-                ]
-              },
-              "height": {
-                "format": "int32",
-                "type": [
-                  "integer",
-                  "null"
-                ]
-              },
-              "id": {
-                "type": [
-                  "string",
-                  "null"
-                ]
-              },
-              "location": {
-                "type": [
-                  "string",
-                  "null"
-                ]
-              },
-              "pHash": {
-                "type": [
-                  "string",
-                  "null"
-                ]
-              },
-              "promptId": {
-                "type": [
-                  "string",
-                  "null"
-                ]
-              },
-              "selfieVerified": {
-                "type": [
-                  "boolean",
-                  "null"
-                ]
-              },
-              "source": {
-                "type": [
-                  "string",
-                  "null"
-                ]
-              },
-              "sourceId": {
-                "type": [
-                  "string",
-                  "null"
-                ]
-              },
-              "url": {
-                "type": "string"
-              },
-              "videoUrl": {
-                "type": [
-                  "string",
-                  "null"
-                ]
-              },
-              "width": {
-                "format": "int32",
-                "type": [
-                  "integer",
-                  "null"
-                ]
-              }
-            },
-            "required": [
-              "url"
-            ],
-            "type": "object"
+          "visible": {
+            "type": "boolean"
           }
         },
+        "required": [
+          "value",
+          "visible"
+        ],
+        "type": "object"
+      },
+      "LanguagesSpoken": {
+        "properties": {
+          "value": {
+            "items": {
+              "format": "int32",
+              "type": "integer"
+            },
+            "type": "array"
+          },
+          "visible": {
+            "type": "boolean"
+          }
+        },
+        "required": [
+          "value",
+          "visible"
+        ],
+        "type": "object"
+      },
+      "LikeItemV2": {
         "properties": {
           "created": {
             "type": "string"
@@ -2937,7 +1273,7 @@
             "type": "string"
           },
           "rating": {
-            "$ref": "#/components/schemas/LikeItemV2/$defs/LikeRating"
+            "$ref": "#/components/schemas/LikeRating"
           },
           "source": {
             "type": "string"
@@ -3017,251 +1353,11 @@
         "type": "object"
       },
       "LikeRating": {
-        "$defs": {
-          "BoundingBox": {
-            "properties": {
-              "bottomRight": {
-                "$ref": "#/components/schemas/LikeRating/$defs/Coordinate",
-                "default": {
-                  "x": 0.0,
-                  "y": 0.0
-                }
-              },
-              "topLeft": {
-                "$ref": "#/components/schemas/LikeRating/$defs/Coordinate",
-                "default": {
-                  "x": 0.0,
-                  "y": 0.0
-                }
-              }
-            },
-            "type": "object"
-          },
-          "Coordinate": {
-            "properties": {
-              "x": {
-                "default": 0.0,
-                "format": "double",
-                "type": "number"
-              },
-              "y": {
-                "default": 0.0,
-                "format": "double",
-                "type": "number"
-              }
-            },
-            "type": "object"
-          },
-          "CreateRateContentPrompt": {
-            "properties": {
-              "answer": {
-                "type": "string"
-              },
-              "contentId": {
-                "type": [
-                  "string",
-                  "null"
-                ]
-              },
-              "question": {
-                "type": "string"
-              }
-            },
-            "required": [
-              "answer",
-              "question"
-            ],
-            "type": "object"
-          },
-          "LikePromptPoll": {
-            "properties": {
-              "contentId": {
-                "type": [
-                  "string",
-                  "null"
-                ]
-              },
-              "options": {
-                "items": {
-                  "type": "string"
-                },
-                "type": "array"
-              },
-              "questionId": {
-                "type": "string"
-              },
-              "selectedOption": {
-                "type": [
-                  "string",
-                  "null"
-                ]
-              },
-              "selectedOptionIndex": {
-                "format": "int32",
-                "type": [
-                  "integer",
-                  "null"
-                ]
-              }
-            },
-            "required": [
-              "options",
-              "questionId"
-            ],
-            "type": "object"
-          },
-          "LikeRatingContentItem": {
-            "properties": {
-              "comment": {
-                "default": null,
-                "type": [
-                  "string",
-                  "null"
-                ]
-              },
-              "photo": {
-                "anyOf": [
-                  {
-                    "$ref": "#/components/schemas/LikeRating/$defs/PhotoAsset"
-                  },
-                  {
-                    "type": "null"
-                  }
-                ],
-                "default": null
-              },
-              "prompt": {
-                "anyOf": [
-                  {
-                    "$ref": "#/components/schemas/LikeRating/$defs/CreateRateContentPrompt"
-                  },
-                  {
-                    "type": "null"
-                  }
-                ],
-                "default": null
-              },
-              "promptPoll": {
-                "anyOf": [
-                  {
-                    "$ref": "#/components/schemas/LikeRating/$defs/LikePromptPoll"
-                  },
-                  {
-                    "type": "null"
-                  }
-                ],
-                "default": null
-              }
-            },
-            "type": "object"
-          },
-          "PhotoAsset": {
-            "properties": {
-              "boundingBox": {
-                "anyOf": [
-                  {
-                    "$ref": "#/components/schemas/LikeRating/$defs/BoundingBox"
-                  },
-                  {
-                    "type": "null"
-                  }
-                ]
-              },
-              "caption": {
-                "type": [
-                  "string",
-                  "null"
-                ]
-              },
-              "cdnId": {
-                "type": [
-                  "string",
-                  "null"
-                ]
-              },
-              "contentId": {
-                "type": [
-                  "string",
-                  "null"
-                ]
-              },
-              "height": {
-                "format": "int32",
-                "type": [
-                  "integer",
-                  "null"
-                ]
-              },
-              "id": {
-                "type": [
-                  "string",
-                  "null"
-                ]
-              },
-              "location": {
-                "type": [
-                  "string",
-                  "null"
-                ]
-              },
-              "pHash": {
-                "type": [
-                  "string",
-                  "null"
-                ]
-              },
-              "promptId": {
-                "type": [
-                  "string",
-                  "null"
-                ]
-              },
-              "selfieVerified": {
-                "type": [
-                  "boolean",
-                  "null"
-                ]
-              },
-              "source": {
-                "type": [
-                  "string",
-                  "null"
-                ]
-              },
-              "sourceId": {
-                "type": [
-                  "string",
-                  "null"
-                ]
-              },
-              "url": {
-                "type": "string"
-              },
-              "videoUrl": {
-                "type": [
-                  "string",
-                  "null"
-                ]
-              },
-              "width": {
-                "format": "int32",
-                "type": [
-                  "integer",
-                  "null"
-                ]
-              }
-            },
-            "required": [
-              "url"
-            ],
-            "type": "object"
-          }
-        },
         "properties": {
           "content": {
             "default": [],
             "items": {
-              "$ref": "#/components/schemas/LikeRating/$defs/LikeRatingContentItem"
+              "$ref": "#/components/schemas/LikeRatingContentItem"
             },
             "type": "array"
           }
@@ -3270,201 +1366,6 @@
         "type": "object"
       },
       "LikeRatingContentItem": {
-        "$defs": {
-          "BoundingBox": {
-            "properties": {
-              "bottomRight": {
-                "$ref": "#/components/schemas/LikeRatingContentItem/$defs/Coordinate",
-                "default": {
-                  "x": 0.0,
-                  "y": 0.0
-                }
-              },
-              "topLeft": {
-                "$ref": "#/components/schemas/LikeRatingContentItem/$defs/Coordinate",
-                "default": {
-                  "x": 0.0,
-                  "y": 0.0
-                }
-              }
-            },
-            "type": "object"
-          },
-          "Coordinate": {
-            "properties": {
-              "x": {
-                "default": 0.0,
-                "format": "double",
-                "type": "number"
-              },
-              "y": {
-                "default": 0.0,
-                "format": "double",
-                "type": "number"
-              }
-            },
-            "type": "object"
-          },
-          "CreateRateContentPrompt": {
-            "properties": {
-              "answer": {
-                "type": "string"
-              },
-              "contentId": {
-                "type": [
-                  "string",
-                  "null"
-                ]
-              },
-              "question": {
-                "type": "string"
-              }
-            },
-            "required": [
-              "answer",
-              "question"
-            ],
-            "type": "object"
-          },
-          "LikePromptPoll": {
-            "properties": {
-              "contentId": {
-                "type": [
-                  "string",
-                  "null"
-                ]
-              },
-              "options": {
-                "items": {
-                  "type": "string"
-                },
-                "type": "array"
-              },
-              "questionId": {
-                "type": "string"
-              },
-              "selectedOption": {
-                "type": [
-                  "string",
-                  "null"
-                ]
-              },
-              "selectedOptionIndex": {
-                "format": "int32",
-                "type": [
-                  "integer",
-                  "null"
-                ]
-              }
-            },
-            "required": [
-              "options",
-              "questionId"
-            ],
-            "type": "object"
-          },
-          "PhotoAsset": {
-            "properties": {
-              "boundingBox": {
-                "anyOf": [
-                  {
-                    "$ref": "#/components/schemas/LikeRatingContentItem/$defs/BoundingBox"
-                  },
-                  {
-                    "type": "null"
-                  }
-                ]
-              },
-              "caption": {
-                "type": [
-                  "string",
-                  "null"
-                ]
-              },
-              "cdnId": {
-                "type": [
-                  "string",
-                  "null"
-                ]
-              },
-              "contentId": {
-                "type": [
-                  "string",
-                  "null"
-                ]
-              },
-              "height": {
-                "format": "int32",
-                "type": [
-                  "integer",
-                  "null"
-                ]
-              },
-              "id": {
-                "type": [
-                  "string",
-                  "null"
-                ]
-              },
-              "location": {
-                "type": [
-                  "string",
-                  "null"
-                ]
-              },
-              "pHash": {
-                "type": [
-                  "string",
-                  "null"
-                ]
-              },
-              "promptId": {
-                "type": [
-                  "string",
-                  "null"
-                ]
-              },
-              "selfieVerified": {
-                "type": [
-                  "boolean",
-                  "null"
-                ]
-              },
-              "source": {
-                "type": [
-                  "string",
-                  "null"
-                ]
-              },
-              "sourceId": {
-                "type": [
-                  "string",
-                  "null"
-                ]
-              },
-              "url": {
-                "type": "string"
-              },
-              "videoUrl": {
-                "type": [
-                  "string",
-                  "null"
-                ]
-              },
-              "width": {
-                "format": "int32",
-                "type": [
-                  "integer",
-                  "null"
-                ]
-              }
-            },
-            "required": [
-              "url"
-            ],
-            "type": "object"
-          }
-        },
         "properties": {
           "comment": {
             "default": null,
@@ -3476,7 +1377,7 @@
           "photo": {
             "anyOf": [
               {
-                "$ref": "#/components/schemas/LikeRatingContentItem/$defs/PhotoAsset"
+                "$ref": "#/components/schemas/PhotoAsset"
               },
               {
                 "type": "null"
@@ -3487,7 +1388,7 @@
           "prompt": {
             "anyOf": [
               {
-                "$ref": "#/components/schemas/LikeRatingContentItem/$defs/CreateRateContentPrompt"
+                "$ref": "#/components/schemas/CreateRateContentPrompt"
               },
               {
                 "type": "null"
@@ -3498,7 +1399,7 @@
           "promptPoll": {
             "anyOf": [
               {
-                "$ref": "#/components/schemas/LikeRatingContentItem/$defs/LikePromptPoll"
+                "$ref": "#/components/schemas/LikePromptPoll"
               },
               {
                 "type": "null"
@@ -3511,31 +1412,9 @@
         "type": "object"
       },
       "LikeResponse": {
-        "$defs": {
-          "LikeLimit": {
-            "properties": {
-              "likes": {
-                "format": "int32",
-                "type": "integer"
-              },
-              "superlikes": {
-                "default": null,
-                "format": "int32",
-                "type": [
-                  "integer",
-                  "null"
-                ]
-              }
-            },
-            "required": [
-              "likes"
-            ],
-            "type": "object"
-          }
-        },
         "properties": {
           "limit": {
-            "$ref": "#/components/schemas/LikeResponse/$defs/LikeLimit"
+            "$ref": "#/components/schemas/LikeLimit"
           }
         },
         "required": [
@@ -3561,333 +1440,6 @@
         "type": "object"
       },
       "LikesV2Response": {
-        "$defs": {
-          "BoundingBox": {
-            "properties": {
-              "bottomRight": {
-                "$ref": "#/components/schemas/LikesV2Response/$defs/Coordinate",
-                "default": {
-                  "x": 0.0,
-                  "y": 0.0
-                }
-              },
-              "topLeft": {
-                "$ref": "#/components/schemas/LikesV2Response/$defs/Coordinate",
-                "default": {
-                  "x": 0.0,
-                  "y": 0.0
-                }
-              }
-            },
-            "type": "object"
-          },
-          "Coordinate": {
-            "properties": {
-              "x": {
-                "default": 0.0,
-                "format": "double",
-                "type": "number"
-              },
-              "y": {
-                "default": 0.0,
-                "format": "double",
-                "type": "number"
-              }
-            },
-            "type": "object"
-          },
-          "CreateRateContentPrompt": {
-            "properties": {
-              "answer": {
-                "type": "string"
-              },
-              "contentId": {
-                "type": [
-                  "string",
-                  "null"
-                ]
-              },
-              "question": {
-                "type": "string"
-              }
-            },
-            "required": [
-              "answer",
-              "question"
-            ],
-            "type": "object"
-          },
-          "LikeItemV2": {
-            "properties": {
-              "created": {
-                "type": "string"
-              },
-              "initiatedWith": {
-                "type": "string"
-              },
-              "playerId": {
-                "type": "string"
-              },
-              "rating": {
-                "$ref": "#/components/schemas/LikesV2Response/$defs/LikeRating"
-              },
-              "source": {
-                "type": "string"
-              },
-              "subjectId": {
-                "type": "string"
-              }
-            },
-            "required": [
-              "playerId",
-              "subjectId",
-              "created",
-              "source",
-              "initiatedWith",
-              "rating"
-            ],
-            "type": "object"
-          },
-          "LikePromptPoll": {
-            "properties": {
-              "contentId": {
-                "type": [
-                  "string",
-                  "null"
-                ]
-              },
-              "options": {
-                "items": {
-                  "type": "string"
-                },
-                "type": "array"
-              },
-              "questionId": {
-                "type": "string"
-              },
-              "selectedOption": {
-                "type": [
-                  "string",
-                  "null"
-                ]
-              },
-              "selectedOptionIndex": {
-                "format": "int32",
-                "type": [
-                  "integer",
-                  "null"
-                ]
-              }
-            },
-            "required": [
-              "options",
-              "questionId"
-            ],
-            "type": "object"
-          },
-          "LikeRating": {
-            "properties": {
-              "content": {
-                "default": [],
-                "items": {
-                  "$ref": "#/components/schemas/LikesV2Response/$defs/LikeRatingContentItem"
-                },
-                "type": "array"
-              }
-            },
-            "type": "object"
-          },
-          "LikeRatingContentItem": {
-            "properties": {
-              "comment": {
-                "default": null,
-                "type": [
-                  "string",
-                  "null"
-                ]
-              },
-              "photo": {
-                "anyOf": [
-                  {
-                    "$ref": "#/components/schemas/LikesV2Response/$defs/PhotoAsset"
-                  },
-                  {
-                    "type": "null"
-                  }
-                ],
-                "default": null
-              },
-              "prompt": {
-                "anyOf": [
-                  {
-                    "$ref": "#/components/schemas/LikesV2Response/$defs/CreateRateContentPrompt"
-                  },
-                  {
-                    "type": "null"
-                  }
-                ],
-                "default": null
-              },
-              "promptPoll": {
-                "anyOf": [
-                  {
-                    "$ref": "#/components/schemas/LikesV2Response/$defs/LikePromptPoll"
-                  },
-                  {
-                    "type": "null"
-                  }
-                ],
-                "default": null
-              }
-            },
-            "type": "object"
-          },
-          "LikeSortV2": {
-            "properties": {
-              "id": {
-                "type": "string"
-              },
-              "title": {
-                "type": "string"
-              }
-            },
-            "required": [
-              "id",
-              "title"
-            ],
-            "type": "object"
-          },
-          "PhotoAsset": {
-            "properties": {
-              "boundingBox": {
-                "anyOf": [
-                  {
-                    "$ref": "#/components/schemas/LikesV2Response/$defs/BoundingBox"
-                  },
-                  {
-                    "type": "null"
-                  }
-                ]
-              },
-              "caption": {
-                "type": [
-                  "string",
-                  "null"
-                ]
-              },
-              "cdnId": {
-                "type": [
-                  "string",
-                  "null"
-                ]
-              },
-              "contentId": {
-                "type": [
-                  "string",
-                  "null"
-                ]
-              },
-              "height": {
-                "format": "int32",
-                "type": [
-                  "integer",
-                  "null"
-                ]
-              },
-              "id": {
-                "type": [
-                  "string",
-                  "null"
-                ]
-              },
-              "location": {
-                "type": [
-                  "string",
-                  "null"
-                ]
-              },
-              "pHash": {
-                "type": [
-                  "string",
-                  "null"
-                ]
-              },
-              "promptId": {
-                "type": [
-                  "string",
-                  "null"
-                ]
-              },
-              "selfieVerified": {
-                "type": [
-                  "boolean",
-                  "null"
-                ]
-              },
-              "source": {
-                "type": [
-                  "string",
-                  "null"
-                ]
-              },
-              "sourceId": {
-                "type": [
-                  "string",
-                  "null"
-                ]
-              },
-              "url": {
-                "type": "string"
-              },
-              "videoUrl": {
-                "type": [
-                  "string",
-                  "null"
-                ]
-              },
-              "width": {
-                "format": "int32",
-                "type": [
-                  "integer",
-                  "null"
-                ]
-              }
-            },
-            "required": [
-              "url"
-            ],
-            "type": "object"
-          },
-          "SortedLikeIdV2": {
-            "properties": {
-              "id": {
-                "type": "string"
-              }
-            },
-            "required": [
-              "id"
-            ],
-            "type": "object"
-          },
-          "SortedLikesGroupV2": {
-            "properties": {
-              "data": {
-                "items": {
-                  "$ref": "#/components/schemas/LikesV2Response/$defs/SortedLikeIdV2"
-                },
-                "type": "array"
-              },
-              "sortID": {
-                "type": "string"
-              }
-            },
-            "required": [
-              "sortID",
-              "data"
-            ],
-            "type": "object"
-          }
-        },
         "properties": {
           "hiddenLikes": {
             "default": [],
@@ -3896,21 +1448,21 @@
           },
           "likes": {
             "items": {
-              "$ref": "#/components/schemas/LikesV2Response/$defs/LikeItemV2"
+              "$ref": "#/components/schemas/LikeItemV2"
             },
             "type": "array"
           },
           "sortedLikes": {
             "default": [],
             "items": {
-              "$ref": "#/components/schemas/LikesV2Response/$defs/SortedLikesGroupV2"
+              "$ref": "#/components/schemas/SortedLikesGroupV2"
             },
             "type": "array"
           },
           "sorts": {
             "default": [],
             "items": {
-              "$ref": "#/components/schemas/LikesV2Response/$defs/LikeSortV2"
+              "$ref": "#/components/schemas/LikeSortV2"
             },
             "type": "array"
           }
@@ -3984,49 +1536,11 @@
         "type": "object"
       },
       "LoginTokens": {
-        "$defs": {
-          "HingeAuthToken": {
-            "properties": {
-              "expires": {
-                "format": "date-time",
-                "type": "string"
-              },
-              "identityId": {
-                "type": "string"
-              },
-              "token": {
-                "type": "string"
-              }
-            },
-            "required": [
-              "identityId",
-              "token",
-              "expires"
-            ],
-            "type": "object"
-          },
-          "SendbirdAuthToken": {
-            "properties": {
-              "expires": {
-                "format": "date-time",
-                "type": "string"
-              },
-              "token": {
-                "type": "string"
-              }
-            },
-            "required": [
-              "token",
-              "expires"
-            ],
-            "type": "object"
-          }
-        },
         "properties": {
           "hingeAuthToken": {
             "anyOf": [
               {
-                "$ref": "#/components/schemas/LoginTokens/$defs/HingeAuthToken"
+                "$ref": "#/components/schemas/HingeAuthToken"
               },
               {
                 "type": "null"
@@ -4037,7 +1551,7 @@
           "sendbirdAuthToken": {
             "anyOf": [
               {
-                "$ref": "#/components/schemas/LoginTokens/$defs/SendbirdAuthToken"
+                "$ref": "#/components/schemas/SendbirdAuthToken"
               },
               {
                 "type": "null"
@@ -4048,6 +1562,41 @@
         },
         "title": "LoginTokens",
         "type": "object"
+      },
+      "MarijuanaStatus": {
+        "properties": {
+          "value": {
+            "$ref": "#/components/schemas/MarijuanaStatusProfile"
+          },
+          "visible": {
+            "type": "boolean"
+          }
+        },
+        "required": [
+          "value",
+          "visible"
+        ],
+        "type": "object"
+      },
+      "MarijuanaStatusPreference": {
+        "enum": [
+          "OpenToAll",
+          "No",
+          "Yes",
+          "Sometimes",
+          "NoPreference"
+        ],
+        "type": "string"
+      },
+      "MarijuanaStatusProfile": {
+        "enum": [
+          "PreferNotToSay",
+          "No",
+          "Yes",
+          "Sometimes",
+          "NoPreference"
+        ],
+        "type": "string"
       },
       "MatchNoteResponse": {
         "properties": {
@@ -4114,47 +1663,11 @@
         "type": "object"
       },
       "PhotoAsset": {
-        "$defs": {
-          "BoundingBox": {
-            "properties": {
-              "bottomRight": {
-                "$ref": "#/components/schemas/PhotoAsset/$defs/Coordinate",
-                "default": {
-                  "x": 0.0,
-                  "y": 0.0
-                }
-              },
-              "topLeft": {
-                "$ref": "#/components/schemas/PhotoAsset/$defs/Coordinate",
-                "default": {
-                  "x": 0.0,
-                  "y": 0.0
-                }
-              }
-            },
-            "type": "object"
-          },
-          "Coordinate": {
-            "properties": {
-              "x": {
-                "default": 0.0,
-                "format": "double",
-                "type": "number"
-              },
-              "y": {
-                "default": 0.0,
-                "format": "double",
-                "type": "number"
-              }
-            },
-            "type": "object"
-          }
-        },
         "properties": {
           "boundingBox": {
             "anyOf": [
               {
-                "$ref": "#/components/schemas/PhotoAsset/$defs/BoundingBox"
+                "$ref": "#/components/schemas/BoundingBox"
               },
               {
                 "type": "null"
@@ -4252,47 +1765,11 @@
         "type": "object"
       },
       "PhotoAssetInput": {
-        "$defs": {
-          "BoundingBox": {
-            "properties": {
-              "bottomRight": {
-                "$ref": "#/components/schemas/PhotoAssetInput/$defs/Coordinate",
-                "default": {
-                  "x": 0.0,
-                  "y": 0.0
-                }
-              },
-              "topLeft": {
-                "$ref": "#/components/schemas/PhotoAssetInput/$defs/Coordinate",
-                "default": {
-                  "x": 0.0,
-                  "y": 0.0
-                }
-              }
-            },
-            "type": "object"
-          },
-          "Coordinate": {
-            "properties": {
-              "x": {
-                "default": 0.0,
-                "format": "double",
-                "type": "number"
-              },
-              "y": {
-                "default": 0.0,
-                "format": "double",
-                "type": "number"
-              }
-            },
-            "type": "object"
-          }
-        },
         "properties": {
           "boundingBox": {
             "anyOf": [
               {
-                "$ref": "#/components/schemas/PhotoAssetInput/$defs/BoundingBox"
+                "$ref": "#/components/schemas/BoundingBox"
               },
               {
                 "type": "null"
@@ -4327,319 +1804,81 @@
         "title": "PhotoAssetInput",
         "type": "object"
       },
-      "Preferences": {
-        "$defs": {
-          "ChildrenStatusPreference": {
-            "enum": [
-              "OpenToAll",
-              "No",
-              "Yes"
-            ],
-            "type": "string"
+      "Politics": {
+        "properties": {
+          "value": {
+            "$ref": "#/components/schemas/PoliticsProfile"
           },
-          "DatingIntentionPreference": {
-            "enum": [
-              "OpenToAll",
-              "LifePartner",
-              "LongTermRelationship",
-              "LongTermOpenToShort",
-              "ShortTermOpenToLong",
-              "ShortTermRelationship",
-              "FiguringOutTheirDatingGoals"
-            ],
-            "type": "string"
-          },
-          "Dealbreakers": {
-            "properties": {
-              "children": {
-                "type": "boolean"
-              },
-              "datingIntentions": {
-                "type": "boolean"
-              },
-              "drinking": {
-                "type": "boolean"
-              },
-              "drugs": {
-                "type": "boolean"
-              },
-              "educationAttained": {
-                "type": "boolean"
-              },
-              "ethnicities": {
-                "type": "boolean"
-              },
-              "familyPlans": {
-                "type": "boolean"
-              },
-              "genderedAge": {
-                "$ref": "#/components/schemas/Preferences/$defs/GenderedDealbreaker"
-              },
-              "genderedHeight": {
-                "$ref": "#/components/schemas/Preferences/$defs/GenderedDealbreaker"
-              },
-              "marijuana": {
-                "type": "boolean"
-              },
-              "maxDistance": {
-                "type": "boolean"
-              },
-              "politics": {
-                "type": "boolean"
-              },
-              "relationshipTypes": {
-                "type": "boolean"
-              },
-              "religions": {
-                "type": "boolean"
-              },
-              "smoking": {
-                "type": "boolean"
-              }
-            },
-            "required": [
-              "marijuana",
-              "smoking",
-              "maxDistance",
-              "drinking",
-              "educationAttained",
-              "genderedHeight",
-              "politics",
-              "relationshipTypes",
-              "drugs",
-              "datingIntentions",
-              "familyPlans",
-              "genderedAge",
-              "religions",
-              "ethnicities",
-              "children"
-            ],
-            "type": "object"
-          },
-          "DrinkingStatusPreference": {
-            "enum": [
-              "OpenToAll",
-              "No",
-              "Yes",
-              "Sometimes"
-            ],
-            "type": "string"
-          },
-          "DrugStatusPreference": {
-            "enum": [
-              "OpenToAll",
-              "No",
-              "Yes",
-              "Sometimes"
-            ],
-            "type": "string"
-          },
-          "EducationAttainedPreference": {
-            "enum": [
-              "OpenToAll",
-              "HighSchool",
-              "TradeSchool",
-              "InCollege",
-              "Undergraduate",
-              "InGradSchool",
-              "Graduate"
-            ],
-            "type": "string"
-          },
-          "EthnicityPreference": {
-            "enum": [
-              "OpenToAll",
-              "AmericanIndian",
-              "BlackAfrican",
-              "EastAsian",
-              "Hispanic",
-              "MiddleEastern",
-              "PacificIslander",
-              "SouthAsian",
-              "White",
-              "Other"
-            ],
-            "type": "string"
-          },
-          "GenderPreferences": {
-            "enum": [
-              "Men",
-              "Women",
-              "Everyone"
-            ],
-            "type": "string"
-          },
-          "GenderedDealbreaker": {
-            "properties": {
-              "0": {
-                "type": [
-                  "boolean",
-                  "null"
-                ]
-              },
-              "1": {
-                "type": [
-                  "boolean",
-                  "null"
-                ]
-              },
-              "3": {
-                "type": [
-                  "boolean",
-                  "null"
-                ]
-              }
-            },
-            "type": "object"
-          },
-          "GenderedRange": {
-            "properties": {
-              "0": {
-                "anyOf": [
-                  {
-                    "$ref": "#/components/schemas/Preferences/$defs/RangeDetails"
-                  },
-                  {
-                    "type": "null"
-                  }
-                ]
-              },
-              "1": {
-                "anyOf": [
-                  {
-                    "$ref": "#/components/schemas/Preferences/$defs/RangeDetails"
-                  },
-                  {
-                    "type": "null"
-                  }
-                ]
-              },
-              "3": {
-                "anyOf": [
-                  {
-                    "$ref": "#/components/schemas/Preferences/$defs/RangeDetails"
-                  },
-                  {
-                    "type": "null"
-                  }
-                ]
-              }
-            },
-            "type": "object"
-          },
-          "MarijuanaStatusPreference": {
-            "enum": [
-              "OpenToAll",
-              "No",
-              "Yes",
-              "Sometimes",
-              "NoPreference"
-            ],
-            "type": "string"
-          },
-          "PoliticsPreference": {
-            "enum": [
-              "OpenToAll",
-              "Liberal",
-              "Moderate",
-              "Conservative",
-              "NotPolitical",
-              "Other"
-            ],
-            "type": "string"
-          },
-          "RangeDetails": {
-            "properties": {
-              "max": {
-                "format": "int32",
-                "type": [
-                  "integer",
-                  "null"
-                ]
-              },
-              "min": {
-                "format": "int32",
-                "type": [
-                  "integer",
-                  "null"
-                ]
-              }
-            },
-            "type": "object"
-          },
-          "RelationshipTypePreference": {
-            "enum": [
-              "OpenToAll",
-              "Monogamy",
-              "EthicalNonMonogamy",
-              "FiguringOutTheirRelationshipType"
-            ],
-            "type": "string"
-          },
-          "ReligionPreference": {
-            "enum": [
-              "OpenToAll",
-              "Spiritual",
-              "Catholic",
-              "Christian",
-              "Hindu",
-              "Jewish",
-              "Muslim",
-              "Buddhist",
-              "Agnostic",
-              "Atheist",
-              "Other",
-              "Sikh"
-            ],
-            "type": "string"
-          },
-          "SmokingStatusPreference": {
-            "enum": [
-              "OpenToAll",
-              "No",
-              "Yes",
-              "Sometimes"
-            ],
-            "type": "string"
+          "visible": {
+            "type": "boolean"
           }
         },
+        "required": [
+          "value",
+          "visible"
+        ],
+        "type": "object"
+      },
+      "PoliticsPreference": {
+        "enum": [
+          "OpenToAll",
+          "Liberal",
+          "Moderate",
+          "Conservative",
+          "NotPolitical",
+          "Other"
+        ],
+        "type": "string"
+      },
+      "PoliticsProfile": {
+        "enum": [
+          "PreferNotToSay",
+          "Liberal",
+          "Moderate",
+          "Conservative",
+          "NotPolitical",
+          "Other"
+        ],
+        "type": "string"
+      },
+      "Preferences": {
         "properties": {
           "children": {
             "items": {
-              "$ref": "#/components/schemas/Preferences/$defs/ChildrenStatusPreference"
+              "$ref": "#/components/schemas/ChildrenStatusPreference"
             },
             "type": "array"
           },
           "datingIntentions": {
             "items": {
-              "$ref": "#/components/schemas/Preferences/$defs/DatingIntentionPreference"
+              "$ref": "#/components/schemas/DatingIntentionPreference"
             },
             "type": "array"
           },
           "dealbreakers": {
-            "$ref": "#/components/schemas/Preferences/$defs/Dealbreakers"
+            "$ref": "#/components/schemas/Dealbreakers"
           },
           "drinking": {
             "items": {
-              "$ref": "#/components/schemas/Preferences/$defs/DrinkingStatusPreference"
+              "$ref": "#/components/schemas/DrinkingStatusPreference"
             },
             "type": "array"
           },
           "drugs": {
             "items": {
-              "$ref": "#/components/schemas/Preferences/$defs/DrugStatusPreference"
+              "$ref": "#/components/schemas/DrugStatusPreference"
             },
             "type": "array"
           },
           "educationAttained": {
             "items": {
-              "$ref": "#/components/schemas/Preferences/$defs/EducationAttainedPreference"
+              "$ref": "#/components/schemas/EducationAttainedPreference"
             },
             "type": "array"
           },
           "ethnicities": {
             "items": {
-              "$ref": "#/components/schemas/Preferences/$defs/EthnicityPreference"
+              "$ref": "#/components/schemas/EthnicityPreference"
             },
             "type": "array"
           },
@@ -4652,19 +1891,19 @@
           },
           "genderPreferences": {
             "items": {
-              "$ref": "#/components/schemas/Preferences/$defs/GenderPreferences"
+              "$ref": "#/components/schemas/GenderPreferences"
             },
             "type": "array"
           },
           "genderedAgeRanges": {
-            "$ref": "#/components/schemas/Preferences/$defs/GenderedRange"
+            "$ref": "#/components/schemas/GenderedRange"
           },
           "genderedHeightRanges": {
-            "$ref": "#/components/schemas/Preferences/$defs/GenderedRange"
+            "$ref": "#/components/schemas/GenderedRange"
           },
           "marijuana": {
             "items": {
-              "$ref": "#/components/schemas/Preferences/$defs/MarijuanaStatusPreference"
+              "$ref": "#/components/schemas/MarijuanaStatusPreference"
             },
             "type": "array"
           },
@@ -4674,25 +1913,25 @@
           },
           "politics": {
             "items": {
-              "$ref": "#/components/schemas/Preferences/$defs/PoliticsPreference"
+              "$ref": "#/components/schemas/PoliticsPreference"
             },
             "type": "array"
           },
           "relationshipTypes": {
             "items": {
-              "$ref": "#/components/schemas/Preferences/$defs/RelationshipTypePreference"
+              "$ref": "#/components/schemas/RelationshipTypePreference"
             },
             "type": "array"
           },
           "religions": {
             "items": {
-              "$ref": "#/components/schemas/Preferences/$defs/ReligionPreference"
+              "$ref": "#/components/schemas/ReligionPreference"
             },
             "type": "array"
           },
           "smoking": {
             "items": {
-              "$ref": "#/components/schemas/Preferences/$defs/SmokingStatusPreference"
+              "$ref": "#/components/schemas/SmokingStatusPreference"
             },
             "type": "array"
           }
@@ -4720,318 +1959,43 @@
         "type": "object"
       },
       "PreferencesResponse": {
-        "$defs": {
-          "ChildrenStatusPreference": {
-            "enum": [
-              "OpenToAll",
-              "No",
-              "Yes"
-            ],
-            "type": "string"
-          },
-          "DatingIntentionPreference": {
-            "enum": [
-              "OpenToAll",
-              "LifePartner",
-              "LongTermRelationship",
-              "LongTermOpenToShort",
-              "ShortTermOpenToLong",
-              "ShortTermRelationship",
-              "FiguringOutTheirDatingGoals"
-            ],
-            "type": "string"
-          },
-          "Dealbreakers": {
-            "properties": {
-              "children": {
-                "type": "boolean"
-              },
-              "datingIntentions": {
-                "type": "boolean"
-              },
-              "drinking": {
-                "type": "boolean"
-              },
-              "drugs": {
-                "type": "boolean"
-              },
-              "educationAttained": {
-                "type": "boolean"
-              },
-              "ethnicities": {
-                "type": "boolean"
-              },
-              "familyPlans": {
-                "type": "boolean"
-              },
-              "genderedAge": {
-                "$ref": "#/components/schemas/PreferencesResponse/$defs/GenderedDealbreaker"
-              },
-              "genderedHeight": {
-                "$ref": "#/components/schemas/PreferencesResponse/$defs/GenderedDealbreaker"
-              },
-              "marijuana": {
-                "type": "boolean"
-              },
-              "maxDistance": {
-                "type": "boolean"
-              },
-              "politics": {
-                "type": "boolean"
-              },
-              "relationshipTypes": {
-                "type": "boolean"
-              },
-              "religions": {
-                "type": "boolean"
-              },
-              "smoking": {
-                "type": "boolean"
-              }
-            },
-            "required": [
-              "marijuana",
-              "smoking",
-              "maxDistance",
-              "drinking",
-              "educationAttained",
-              "genderedHeight",
-              "politics",
-              "relationshipTypes",
-              "drugs",
-              "datingIntentions",
-              "familyPlans",
-              "genderedAge",
-              "religions",
-              "ethnicities",
-              "children"
-            ],
-            "type": "object"
-          },
-          "DrinkingStatusPreference": {
-            "enum": [
-              "OpenToAll",
-              "No",
-              "Yes",
-              "Sometimes"
-            ],
-            "type": "string"
-          },
-          "DrugStatusPreference": {
-            "enum": [
-              "OpenToAll",
-              "No",
-              "Yes",
-              "Sometimes"
-            ],
-            "type": "string"
-          },
-          "EducationAttainedPreference": {
-            "enum": [
-              "OpenToAll",
-              "HighSchool",
-              "TradeSchool",
-              "InCollege",
-              "Undergraduate",
-              "InGradSchool",
-              "Graduate"
-            ],
-            "type": "string"
-          },
-          "EthnicityPreference": {
-            "enum": [
-              "OpenToAll",
-              "AmericanIndian",
-              "BlackAfrican",
-              "EastAsian",
-              "Hispanic",
-              "MiddleEastern",
-              "PacificIslander",
-              "SouthAsian",
-              "White",
-              "Other"
-            ],
-            "type": "string"
-          },
-          "GenderPreferences": {
-            "enum": [
-              "Men",
-              "Women",
-              "Everyone"
-            ],
-            "type": "string"
-          },
-          "GenderedDealbreaker": {
-            "properties": {
-              "0": {
-                "type": [
-                  "boolean",
-                  "null"
-                ]
-              },
-              "1": {
-                "type": [
-                  "boolean",
-                  "null"
-                ]
-              },
-              "3": {
-                "type": [
-                  "boolean",
-                  "null"
-                ]
-              }
-            },
-            "type": "object"
-          },
-          "GenderedRange": {
-            "properties": {
-              "0": {
-                "anyOf": [
-                  {
-                    "$ref": "#/components/schemas/PreferencesResponse/$defs/RangeDetails"
-                  },
-                  {
-                    "type": "null"
-                  }
-                ]
-              },
-              "1": {
-                "anyOf": [
-                  {
-                    "$ref": "#/components/schemas/PreferencesResponse/$defs/RangeDetails"
-                  },
-                  {
-                    "type": "null"
-                  }
-                ]
-              },
-              "3": {
-                "anyOf": [
-                  {
-                    "$ref": "#/components/schemas/PreferencesResponse/$defs/RangeDetails"
-                  },
-                  {
-                    "type": "null"
-                  }
-                ]
-              }
-            },
-            "type": "object"
-          },
-          "MarijuanaStatusPreference": {
-            "enum": [
-              "OpenToAll",
-              "No",
-              "Yes",
-              "Sometimes",
-              "NoPreference"
-            ],
-            "type": "string"
-          },
-          "PoliticsPreference": {
-            "enum": [
-              "OpenToAll",
-              "Liberal",
-              "Moderate",
-              "Conservative",
-              "NotPolitical",
-              "Other"
-            ],
-            "type": "string"
-          },
-          "RangeDetails": {
-            "properties": {
-              "max": {
-                "format": "int32",
-                "type": [
-                  "integer",
-                  "null"
-                ]
-              },
-              "min": {
-                "format": "int32",
-                "type": [
-                  "integer",
-                  "null"
-                ]
-              }
-            },
-            "type": "object"
-          },
-          "RelationshipTypePreference": {
-            "enum": [
-              "OpenToAll",
-              "Monogamy",
-              "EthicalNonMonogamy",
-              "FiguringOutTheirRelationshipType"
-            ],
-            "type": "string"
-          },
-          "ReligionPreference": {
-            "enum": [
-              "OpenToAll",
-              "Spiritual",
-              "Catholic",
-              "Christian",
-              "Hindu",
-              "Jewish",
-              "Muslim",
-              "Buddhist",
-              "Agnostic",
-              "Atheist",
-              "Other",
-              "Sikh"
-            ],
-            "type": "string"
-          },
-          "SmokingStatusPreference": {
-            "enum": [
-              "OpenToAll",
-              "No",
-              "Yes",
-              "Sometimes"
-            ],
-            "type": "string"
-          }
-        },
         "properties": {
           "children": {
             "items": {
-              "$ref": "#/components/schemas/PreferencesResponse/$defs/ChildrenStatusPreference"
+              "$ref": "#/components/schemas/ChildrenStatusPreference"
             },
             "type": "array"
           },
           "datingIntentions": {
             "items": {
-              "$ref": "#/components/schemas/PreferencesResponse/$defs/DatingIntentionPreference"
+              "$ref": "#/components/schemas/DatingIntentionPreference"
             },
             "type": "array"
           },
           "dealbreakers": {
-            "$ref": "#/components/schemas/PreferencesResponse/$defs/Dealbreakers"
+            "$ref": "#/components/schemas/Dealbreakers"
           },
           "drinking": {
             "items": {
-              "$ref": "#/components/schemas/PreferencesResponse/$defs/DrinkingStatusPreference"
+              "$ref": "#/components/schemas/DrinkingStatusPreference"
             },
             "type": "array"
           },
           "drugs": {
             "items": {
-              "$ref": "#/components/schemas/PreferencesResponse/$defs/DrugStatusPreference"
+              "$ref": "#/components/schemas/DrugStatusPreference"
             },
             "type": "array"
           },
           "educationAttained": {
             "items": {
-              "$ref": "#/components/schemas/PreferencesResponse/$defs/EducationAttainedPreference"
+              "$ref": "#/components/schemas/EducationAttainedPreference"
             },
             "type": "array"
           },
           "ethnicities": {
             "items": {
-              "$ref": "#/components/schemas/PreferencesResponse/$defs/EthnicityPreference"
+              "$ref": "#/components/schemas/EthnicityPreference"
             },
             "type": "array"
           },
@@ -5044,19 +2008,19 @@
           },
           "genderPreferences": {
             "items": {
-              "$ref": "#/components/schemas/PreferencesResponse/$defs/GenderPreferences"
+              "$ref": "#/components/schemas/GenderPreferences"
             },
             "type": "array"
           },
           "genderedAgeRanges": {
-            "$ref": "#/components/schemas/PreferencesResponse/$defs/GenderedRange"
+            "$ref": "#/components/schemas/GenderedRange"
           },
           "genderedHeightRanges": {
-            "$ref": "#/components/schemas/PreferencesResponse/$defs/GenderedRange"
+            "$ref": "#/components/schemas/GenderedRange"
           },
           "marijuana": {
             "items": {
-              "$ref": "#/components/schemas/PreferencesResponse/$defs/MarijuanaStatusPreference"
+              "$ref": "#/components/schemas/MarijuanaStatusPreference"
             },
             "type": "array"
           },
@@ -5066,25 +2030,25 @@
           },
           "politics": {
             "items": {
-              "$ref": "#/components/schemas/PreferencesResponse/$defs/PoliticsPreference"
+              "$ref": "#/components/schemas/PoliticsPreference"
             },
             "type": "array"
           },
           "relationshipTypes": {
             "items": {
-              "$ref": "#/components/schemas/PreferencesResponse/$defs/RelationshipTypePreference"
+              "$ref": "#/components/schemas/RelationshipTypePreference"
             },
             "type": "array"
           },
           "religions": {
             "items": {
-              "$ref": "#/components/schemas/PreferencesResponse/$defs/ReligionPreference"
+              "$ref": "#/components/schemas/ReligionPreference"
             },
             "type": "array"
           },
           "smoking": {
             "items": {
-              "$ref": "#/components/schemas/PreferencesResponse/$defs/SmokingStatusPreference"
+              "$ref": "#/components/schemas/SmokingStatusPreference"
             },
             "type": "array"
           }
@@ -5118,780 +2082,6 @@
         "type": "array"
       },
       "Profile": {
-        "$defs": {
-          "BoundingBox": {
-            "properties": {
-              "bottomRight": {
-                "$ref": "#/components/schemas/Profile/$defs/Coordinate",
-                "default": {
-                  "x": 0.0,
-                  "y": 0.0
-                }
-              },
-              "topLeft": {
-                "$ref": "#/components/schemas/Profile/$defs/Coordinate",
-                "default": {
-                  "x": 0.0,
-                  "y": 0.0
-                }
-              }
-            },
-            "type": "object"
-          },
-          "ChildrenStatus": {
-            "properties": {
-              "value": {
-                "$ref": "#/components/schemas/Profile/$defs/ChildrenStatusProfile"
-              },
-              "visible": {
-                "type": "boolean"
-              }
-            },
-            "required": [
-              "value",
-              "visible"
-            ],
-            "type": "object"
-          },
-          "ChildrenStatusProfile": {
-            "enum": [
-              "PreferNotToSay",
-              "No",
-              "Yes"
-            ],
-            "type": "string"
-          },
-          "Coordinate": {
-            "properties": {
-              "x": {
-                "default": 0.0,
-                "format": "double",
-                "type": "number"
-              },
-              "y": {
-                "default": 0.0,
-                "format": "double",
-                "type": "number"
-              }
-            },
-            "type": "object"
-          },
-          "DatingIntention": {
-            "properties": {
-              "value": {
-                "$ref": "#/components/schemas/Profile/$defs/DatingIntentionProfile"
-              },
-              "visible": {
-                "type": "boolean"
-              }
-            },
-            "required": [
-              "value",
-              "visible"
-            ],
-            "type": "object"
-          },
-          "DatingIntentionProfile": {
-            "enum": [
-              "PreferNotToSay",
-              "LifePartner",
-              "LongTermRelationship",
-              "LongTermOpenToShort",
-              "ShortTermOpenToLong",
-              "ShortTermRelationship",
-              "FiguringOutTheirDatingGoals"
-            ],
-            "type": "string"
-          },
-          "DrinkingStatus": {
-            "properties": {
-              "value": {
-                "$ref": "#/components/schemas/Profile/$defs/DrinkingStatusProfile"
-              },
-              "visible": {
-                "type": "boolean"
-              }
-            },
-            "required": [
-              "value",
-              "visible"
-            ],
-            "type": "object"
-          },
-          "DrinkingStatusProfile": {
-            "enum": [
-              "PreferNotToSay",
-              "No",
-              "Yes",
-              "Sometimes"
-            ],
-            "type": "string"
-          },
-          "DrugStatus": {
-            "properties": {
-              "value": {
-                "$ref": "#/components/schemas/Profile/$defs/DrugStatusProfile"
-              },
-              "visible": {
-                "type": "boolean"
-              }
-            },
-            "required": [
-              "value",
-              "visible"
-            ],
-            "type": "object"
-          },
-          "DrugStatusProfile": {
-            "enum": [
-              "PreferNotToSay",
-              "No",
-              "Yes",
-              "Sometimes"
-            ],
-            "type": "string"
-          },
-          "EducationAttainedProfile": {
-            "enum": [
-              "PreferNotToSay",
-              "HighSchool",
-              "TradeSchool",
-              "InCollege",
-              "Undergraduate",
-              "InGradSchool",
-              "Graduate"
-            ],
-            "type": "string"
-          },
-          "Educations": {
-            "properties": {
-              "value": {
-                "items": {
-                  "type": "string"
-                },
-                "type": "array"
-              },
-              "visible": {
-                "type": "boolean"
-              }
-            },
-            "required": [
-              "value",
-              "visible"
-            ],
-            "type": "object"
-          },
-          "Ethnicities": {
-            "properties": {
-              "value": {
-                "items": {
-                  "$ref": "#/components/schemas/Profile/$defs/EthnicityProfile"
-                },
-                "type": "array"
-              },
-              "visible": {
-                "type": "boolean"
-              }
-            },
-            "required": [
-              "value",
-              "visible"
-            ],
-            "type": "object"
-          },
-          "EthnicityProfile": {
-            "enum": [
-              "PreferNotToSay",
-              "AmericanIndian",
-              "BlackAfrican",
-              "EastAsian",
-              "Hispanic",
-              "MiddleEastern",
-              "PacificIslander",
-              "SouthAsian",
-              "White",
-              "Other"
-            ],
-            "type": "string"
-          },
-          "FamilyPlans": {
-            "properties": {
-              "value": {
-                "format": "int32",
-                "type": "integer"
-              },
-              "visible": {
-                "type": "boolean"
-              }
-            },
-            "required": [
-              "value",
-              "visible"
-            ],
-            "type": "object"
-          },
-          "Feedback": {
-            "properties": {
-              "detail": {
-                "type": "string"
-              },
-              "evaluation": {
-                "type": "string"
-              },
-              "feedbackToken": {
-                "type": "string"
-              }
-            },
-            "required": [
-              "evaluation",
-              "detail",
-              "feedbackToken"
-            ],
-            "type": "object"
-          },
-          "GenderEnum": {
-            "enum": [
-              "Man",
-              "Woman",
-              "NonBinary"
-            ],
-            "type": "string"
-          },
-          "GenderIdentityId": {
-            "properties": {
-              "value": {
-                "format": "int32",
-                "type": "integer"
-              },
-              "visible": {
-                "type": "boolean"
-              }
-            },
-            "required": [
-              "value",
-              "visible"
-            ],
-            "type": "object"
-          },
-          "Hometown": {
-            "properties": {
-              "value": {
-                "type": "string"
-              },
-              "visible": {
-                "type": "boolean"
-              }
-            },
-            "required": [
-              "value",
-              "visible"
-            ],
-            "type": "object"
-          },
-          "JobTitle": {
-            "properties": {
-              "value": {
-                "type": "string"
-              },
-              "visible": {
-                "type": "boolean"
-              }
-            },
-            "required": [
-              "value",
-              "visible"
-            ],
-            "type": "object"
-          },
-          "LanguagesSpoken": {
-            "properties": {
-              "value": {
-                "items": {
-                  "format": "int32",
-                  "type": "integer"
-                },
-                "type": "array"
-              },
-              "visible": {
-                "type": "boolean"
-              }
-            },
-            "required": [
-              "value",
-              "visible"
-            ],
-            "type": "object"
-          },
-          "Location": {
-            "properties": {
-              "adminArea1Long": {
-                "type": [
-                  "string",
-                  "null"
-                ]
-              },
-              "adminArea1Short": {
-                "type": [
-                  "string",
-                  "null"
-                ]
-              },
-              "adminArea2": {
-                "type": [
-                  "string",
-                  "null"
-                ]
-              },
-              "countryShort": {
-                "type": [
-                  "string",
-                  "null"
-                ]
-              },
-              "latitude": {
-                "format": "double",
-                "type": [
-                  "number",
-                  "null"
-                ]
-              },
-              "longitude": {
-                "format": "double",
-                "type": [
-                  "number",
-                  "null"
-                ]
-              },
-              "metroArea": {
-                "type": [
-                  "string",
-                  "null"
-                ]
-              },
-              "metroAreaV2": {
-                "type": [
-                  "string",
-                  "null"
-                ]
-              },
-              "name": {
-                "type": "string"
-              }
-            },
-            "required": [
-              "name"
-            ],
-            "type": "object"
-          },
-          "MarijuanaStatus": {
-            "properties": {
-              "value": {
-                "$ref": "#/components/schemas/Profile/$defs/MarijuanaStatusProfile"
-              },
-              "visible": {
-                "type": "boolean"
-              }
-            },
-            "required": [
-              "value",
-              "visible"
-            ],
-            "type": "object"
-          },
-          "MarijuanaStatusProfile": {
-            "enum": [
-              "PreferNotToSay",
-              "No",
-              "Yes",
-              "Sometimes",
-              "NoPreference"
-            ],
-            "type": "string"
-          },
-          "PhotoAsset": {
-            "properties": {
-              "boundingBox": {
-                "anyOf": [
-                  {
-                    "$ref": "#/components/schemas/Profile/$defs/BoundingBox"
-                  },
-                  {
-                    "type": "null"
-                  }
-                ]
-              },
-              "caption": {
-                "type": [
-                  "string",
-                  "null"
-                ]
-              },
-              "cdnId": {
-                "type": [
-                  "string",
-                  "null"
-                ]
-              },
-              "contentId": {
-                "type": [
-                  "string",
-                  "null"
-                ]
-              },
-              "height": {
-                "format": "int32",
-                "type": [
-                  "integer",
-                  "null"
-                ]
-              },
-              "id": {
-                "type": [
-                  "string",
-                  "null"
-                ]
-              },
-              "location": {
-                "type": [
-                  "string",
-                  "null"
-                ]
-              },
-              "pHash": {
-                "type": [
-                  "string",
-                  "null"
-                ]
-              },
-              "promptId": {
-                "type": [
-                  "string",
-                  "null"
-                ]
-              },
-              "selfieVerified": {
-                "type": [
-                  "boolean",
-                  "null"
-                ]
-              },
-              "source": {
-                "type": [
-                  "string",
-                  "null"
-                ]
-              },
-              "sourceId": {
-                "type": [
-                  "string",
-                  "null"
-                ]
-              },
-              "url": {
-                "type": "string"
-              },
-              "videoUrl": {
-                "type": [
-                  "string",
-                  "null"
-                ]
-              },
-              "width": {
-                "format": "int32",
-                "type": [
-                  "integer",
-                  "null"
-                ]
-              }
-            },
-            "required": [
-              "url"
-            ],
-            "type": "object"
-          },
-          "Politics": {
-            "properties": {
-              "value": {
-                "$ref": "#/components/schemas/Profile/$defs/PoliticsProfile"
-              },
-              "visible": {
-                "type": "boolean"
-              }
-            },
-            "required": [
-              "value",
-              "visible"
-            ],
-            "type": "object"
-          },
-          "PoliticsProfile": {
-            "enum": [
-              "PreferNotToSay",
-              "Liberal",
-              "Moderate",
-              "Conservative",
-              "NotPolitical",
-              "Other"
-            ],
-            "type": "string"
-          },
-          "ProfileAnswer": {
-            "properties": {
-              "cdnId": {
-                "type": [
-                  "string",
-                  "null"
-                ]
-              },
-              "content": {
-                "type": [
-                  "string",
-                  "null"
-                ]
-              },
-              "contentId": {
-                "type": [
-                  "string",
-                  "null"
-                ]
-              },
-              "feedback": {
-                "anyOf": [
-                  {
-                    "$ref": "#/components/schemas/Profile/$defs/Feedback"
-                  },
-                  {
-                    "type": "null"
-                  }
-                ]
-              },
-              "position": {
-                "format": "int32",
-                "type": [
-                  "integer",
-                  "null"
-                ]
-              },
-              "promptId": {
-                "type": [
-                  "string",
-                  "null"
-                ]
-              },
-              "questionId": {
-                "type": [
-                  "string",
-                  "null"
-                ]
-              },
-              "response": {
-                "type": [
-                  "string",
-                  "null"
-                ]
-              },
-              "transcription": {
-                "type": [
-                  "string",
-                  "null"
-                ]
-              },
-              "transcriptionMetadata": true,
-              "type": {
-                "type": [
-                  "string",
-                  "null"
-                ]
-              },
-              "url": {
-                "type": [
-                  "string",
-                  "null"
-                ]
-              },
-              "waveform": {
-                "type": [
-                  "string",
-                  "null"
-                ]
-              }
-            },
-            "type": "object"
-          },
-          "ProfileName": {
-            "properties": {
-              "firstName": {
-                "type": "string"
-              },
-              "lastName": {
-                "default": null,
-                "type": [
-                  "string",
-                  "null"
-                ]
-              }
-            },
-            "required": [
-              "firstName"
-            ],
-            "type": "object"
-          },
-          "Pronouns": {
-            "properties": {
-              "value": {
-                "items": {
-                  "format": "int32",
-                  "type": "integer"
-                },
-                "type": "array"
-              },
-              "visible": {
-                "type": "boolean"
-              }
-            },
-            "required": [
-              "value",
-              "visible"
-            ],
-            "type": "object"
-          },
-          "RelationshipTypeIds": {
-            "properties": {
-              "value": {
-                "items": {
-                  "$ref": "#/components/schemas/Profile/$defs/RelationshipTypeProfile"
-                },
-                "type": "array"
-              },
-              "visible": {
-                "type": "boolean"
-              }
-            },
-            "required": [
-              "value",
-              "visible"
-            ],
-            "type": "object"
-          },
-          "RelationshipTypeProfile": {
-            "enum": [
-              "PreferNotToSay",
-              "Monogamy",
-              "EthicalNonMonogamy",
-              "FiguringOutTheirRelationshipType"
-            ],
-            "type": "string"
-          },
-          "Religion": {
-            "properties": {
-              "value": {
-                "items": {
-                  "$ref": "#/components/schemas/Profile/$defs/ReligionProfile"
-                },
-                "type": "array"
-              },
-              "visible": {
-                "type": "boolean"
-              }
-            },
-            "required": [
-              "value",
-              "visible"
-            ],
-            "type": "object"
-          },
-          "ReligionProfile": {
-            "enum": [
-              "PreferNotToSay",
-              "Spiritual",
-              "Catholic",
-              "Christian",
-              "Hindu",
-              "Jewish",
-              "Muslim",
-              "Buddhist",
-              "Agnostic",
-              "Atheist",
-              "Other",
-              "Sikh"
-            ],
-            "type": "string"
-          },
-          "SexualOrientations": {
-            "properties": {
-              "value": {
-                "items": {
-                  "format": "int32",
-                  "type": "integer"
-                },
-                "type": "array"
-              },
-              "visible": {
-                "type": "boolean"
-              }
-            },
-            "required": [
-              "value",
-              "visible"
-            ],
-            "type": "object"
-          },
-          "SmokingStatus": {
-            "properties": {
-              "value": {
-                "$ref": "#/components/schemas/Profile/$defs/SmokingStatusProfile"
-              },
-              "visible": {
-                "type": "boolean"
-              }
-            },
-            "required": [
-              "value",
-              "visible"
-            ],
-            "type": "object"
-          },
-          "SmokingStatusProfile": {
-            "enum": [
-              "PreferNotToSay",
-              "No",
-              "Yes",
-              "Sometimes"
-            ],
-            "type": "string"
-          },
-          "Works": {
-            "properties": {
-              "value": {
-                "type": "string"
-              },
-              "visible": {
-                "type": "boolean"
-              }
-            },
-            "required": [
-              "value",
-              "visible"
-            ],
-            "type": "object"
-          },
-          "Zodiac": {
-            "properties": {
-              "value": {
-                "format": "int32",
-                "type": "integer"
-              },
-              "visible": {
-                "type": "boolean"
-              }
-            },
-            "required": [
-              "value",
-              "visible"
-            ],
-            "type": "object"
-          }
-        },
         "properties": {
           "age": {
             "format": "int32",
@@ -5903,7 +2093,7 @@
           "answers": {
             "default": [],
             "items": {
-              "$ref": "#/components/schemas/Profile/$defs/ProfileAnswer"
+              "$ref": "#/components/schemas/ProfileAnswer"
             },
             "type": "array"
           },
@@ -5916,7 +2106,7 @@
           "children": {
             "anyOf": [
               {
-                "$ref": "#/components/schemas/Profile/$defs/ChildrenStatus"
+                "$ref": "#/components/schemas/ChildrenStatus"
               },
               {
                 "type": "null"
@@ -5933,7 +2123,7 @@
           "datingIntention": {
             "anyOf": [
               {
-                "$ref": "#/components/schemas/Profile/$defs/DatingIntention"
+                "$ref": "#/components/schemas/DatingIntention"
               },
               {
                 "type": "null"
@@ -5955,7 +2145,7 @@
           "drinking": {
             "anyOf": [
               {
-                "$ref": "#/components/schemas/Profile/$defs/DrinkingStatus"
+                "$ref": "#/components/schemas/DrinkingStatus"
               },
               {
                 "type": "null"
@@ -5965,7 +2155,7 @@
           "drugs": {
             "anyOf": [
               {
-                "$ref": "#/components/schemas/Profile/$defs/DrugStatus"
+                "$ref": "#/components/schemas/DrugStatus"
               },
               {
                 "type": "null"
@@ -5975,7 +2165,7 @@
           "educationAttained": {
             "anyOf": [
               {
-                "$ref": "#/components/schemas/Profile/$defs/EducationAttainedProfile"
+                "$ref": "#/components/schemas/EducationAttainedProfile"
               },
               {
                 "type": "null"
@@ -5985,7 +2175,7 @@
           "educations": {
             "anyOf": [
               {
-                "$ref": "#/components/schemas/Profile/$defs/Educations"
+                "$ref": "#/components/schemas/Educations"
               },
               {
                 "type": "null"
@@ -6007,7 +2197,7 @@
           "ethnicities": {
             "anyOf": [
               {
-                "$ref": "#/components/schemas/Profile/$defs/Ethnicities"
+                "$ref": "#/components/schemas/Ethnicities"
               },
               {
                 "type": "null"
@@ -6023,7 +2213,7 @@
           "familyPlans": {
             "anyOf": [
               {
-                "$ref": "#/components/schemas/Profile/$defs/FamilyPlans"
+                "$ref": "#/components/schemas/FamilyPlans"
               },
               {
                 "type": "null"
@@ -6042,7 +2232,7 @@
           "genderId": {
             "anyOf": [
               {
-                "$ref": "#/components/schemas/Profile/$defs/GenderEnum"
+                "$ref": "#/components/schemas/GenderEnum"
               },
               {
                 "type": "null"
@@ -6058,7 +2248,7 @@
           "genderIdentityId": {
             "anyOf": [
               {
-                "$ref": "#/components/schemas/Profile/$defs/GenderIdentityId"
+                "$ref": "#/components/schemas/GenderIdentityId"
               },
               {
                 "type": "null"
@@ -6075,7 +2265,7 @@
           "hometown": {
             "anyOf": [
               {
-                "$ref": "#/components/schemas/Profile/$defs/Hometown"
+                "$ref": "#/components/schemas/Hometown"
               },
               {
                 "type": "null"
@@ -6085,7 +2275,7 @@
           "jobTitle": {
             "anyOf": [
               {
-                "$ref": "#/components/schemas/Profile/$defs/JobTitle"
+                "$ref": "#/components/schemas/JobTitle"
               },
               {
                 "type": "null"
@@ -6095,7 +2285,7 @@
           "languagesSpoken": {
             "anyOf": [
               {
-                "$ref": "#/components/schemas/Profile/$defs/LanguagesSpoken"
+                "$ref": "#/components/schemas/LanguagesSpoken"
               },
               {
                 "type": "null"
@@ -6116,12 +2306,12 @@
             ]
           },
           "location": {
-            "$ref": "#/components/schemas/Profile/$defs/Location"
+            "$ref": "#/components/schemas/Location"
           },
           "marijuana": {
             "anyOf": [
               {
-                "$ref": "#/components/schemas/Profile/$defs/MarijuanaStatus"
+                "$ref": "#/components/schemas/MarijuanaStatus"
               },
               {
                 "type": "null"
@@ -6131,7 +2321,7 @@
           "name": {
             "anyOf": [
               {
-                "$ref": "#/components/schemas/Profile/$defs/ProfileName"
+                "$ref": "#/components/schemas/ProfileName"
               },
               {
                 "type": "null"
@@ -6148,14 +2338,14 @@
           "photos": {
             "default": [],
             "items": {
-              "$ref": "#/components/schemas/Profile/$defs/PhotoAsset"
+              "$ref": "#/components/schemas/PhotoAsset"
             },
             "type": "array"
           },
           "politics": {
             "anyOf": [
               {
-                "$ref": "#/components/schemas/Profile/$defs/Politics"
+                "$ref": "#/components/schemas/Politics"
               },
               {
                 "type": "null"
@@ -6165,7 +2355,7 @@
           "pronouns": {
             "anyOf": [
               {
-                "$ref": "#/components/schemas/Profile/$defs/Pronouns"
+                "$ref": "#/components/schemas/Pronouns"
               },
               {
                 "type": "null"
@@ -6175,7 +2365,7 @@
           "relationshipTypeIds": {
             "anyOf": [
               {
-                "$ref": "#/components/schemas/Profile/$defs/RelationshipTypeIds"
+                "$ref": "#/components/schemas/RelationshipTypeIds"
               },
               {
                 "type": "null"
@@ -6191,7 +2381,7 @@
           "religions": {
             "anyOf": [
               {
-                "$ref": "#/components/schemas/Profile/$defs/Religion"
+                "$ref": "#/components/schemas/Religion"
               },
               {
                 "type": "null"
@@ -6207,7 +2397,7 @@
           "sexualOrientations": {
             "anyOf": [
               {
-                "$ref": "#/components/schemas/Profile/$defs/SexualOrientations"
+                "$ref": "#/components/schemas/SexualOrientations"
               },
               {
                 "type": "null"
@@ -6217,7 +2407,7 @@
           "smoking": {
             "anyOf": [
               {
-                "$ref": "#/components/schemas/Profile/$defs/SmokingStatus"
+                "$ref": "#/components/schemas/SmokingStatus"
               },
               {
                 "type": "null"
@@ -6227,7 +2417,7 @@
           "works": {
             "anyOf": [
               {
-                "$ref": "#/components/schemas/Profile/$defs/Works"
+                "$ref": "#/components/schemas/Works"
               },
               {
                 "type": "null"
@@ -6237,7 +2427,7 @@
           "zodiac": {
             "anyOf": [
               {
-                "$ref": "#/components/schemas/Profile/$defs/Zodiac"
+                "$ref": "#/components/schemas/Zodiac"
               },
               {
                 "type": "null"
@@ -6253,27 +2443,6 @@
         "type": "object"
       },
       "ProfileAnswer": {
-        "$defs": {
-          "Feedback": {
-            "properties": {
-              "detail": {
-                "type": "string"
-              },
-              "evaluation": {
-                "type": "string"
-              },
-              "feedbackToken": {
-                "type": "string"
-              }
-            },
-            "required": [
-              "evaluation",
-              "detail",
-              "feedbackToken"
-            ],
-            "type": "object"
-          }
-        },
         "properties": {
           "cdnId": {
             "type": [
@@ -6296,7 +2465,7 @@
           "feedback": {
             "anyOf": [
               {
-                "$ref": "#/components/schemas/ProfileAnswer/$defs/Feedback"
+                "$ref": "#/components/schemas/Feedback"
               },
               {
                 "type": "null"
@@ -6358,278 +2527,21 @@
         "type": "object"
       },
       "ProfileContent": {
-        "$defs": {
-          "BoundingBox": {
-            "properties": {
-              "bottomRight": {
-                "$ref": "#/components/schemas/ProfileContent/$defs/Coordinate",
-                "default": {
-                  "x": 0.0,
-                  "y": 0.0
-                }
-              },
-              "topLeft": {
-                "$ref": "#/components/schemas/ProfileContent/$defs/Coordinate",
-                "default": {
-                  "x": 0.0,
-                  "y": 0.0
-                }
-              }
-            },
-            "type": "object"
-          },
-          "Coordinate": {
-            "properties": {
-              "x": {
-                "default": 0.0,
-                "format": "double",
-                "type": "number"
-              },
-              "y": {
-                "default": 0.0,
-                "format": "double",
-                "type": "number"
-              }
-            },
-            "type": "object"
-          },
-          "Feedback": {
-            "properties": {
-              "detail": {
-                "type": "string"
-              },
-              "evaluation": {
-                "type": "string"
-              },
-              "feedbackToken": {
-                "type": "string"
-              }
-            },
-            "required": [
-              "evaluation",
-              "detail",
-              "feedbackToken"
-            ],
-            "type": "object"
-          },
-          "PhotoAsset": {
-            "properties": {
-              "boundingBox": {
-                "anyOf": [
-                  {
-                    "$ref": "#/components/schemas/ProfileContent/$defs/BoundingBox"
-                  },
-                  {
-                    "type": "null"
-                  }
-                ]
-              },
-              "caption": {
-                "type": [
-                  "string",
-                  "null"
-                ]
-              },
-              "cdnId": {
-                "type": [
-                  "string",
-                  "null"
-                ]
-              },
-              "contentId": {
-                "type": [
-                  "string",
-                  "null"
-                ]
-              },
-              "height": {
-                "format": "int32",
-                "type": [
-                  "integer",
-                  "null"
-                ]
-              },
-              "id": {
-                "type": [
-                  "string",
-                  "null"
-                ]
-              },
-              "location": {
-                "type": [
-                  "string",
-                  "null"
-                ]
-              },
-              "pHash": {
-                "type": [
-                  "string",
-                  "null"
-                ]
-              },
-              "promptId": {
-                "type": [
-                  "string",
-                  "null"
-                ]
-              },
-              "selfieVerified": {
-                "type": [
-                  "boolean",
-                  "null"
-                ]
-              },
-              "source": {
-                "type": [
-                  "string",
-                  "null"
-                ]
-              },
-              "sourceId": {
-                "type": [
-                  "string",
-                  "null"
-                ]
-              },
-              "url": {
-                "type": "string"
-              },
-              "videoUrl": {
-                "type": [
-                  "string",
-                  "null"
-                ]
-              },
-              "width": {
-                "format": "int32",
-                "type": [
-                  "integer",
-                  "null"
-                ]
-              }
-            },
-            "required": [
-              "url"
-            ],
-            "type": "object"
-          },
-          "ProfileAnswer": {
-            "properties": {
-              "cdnId": {
-                "type": [
-                  "string",
-                  "null"
-                ]
-              },
-              "content": {
-                "type": [
-                  "string",
-                  "null"
-                ]
-              },
-              "contentId": {
-                "type": [
-                  "string",
-                  "null"
-                ]
-              },
-              "feedback": {
-                "anyOf": [
-                  {
-                    "$ref": "#/components/schemas/ProfileContent/$defs/Feedback"
-                  },
-                  {
-                    "type": "null"
-                  }
-                ]
-              },
-              "position": {
-                "format": "int32",
-                "type": [
-                  "integer",
-                  "null"
-                ]
-              },
-              "promptId": {
-                "type": [
-                  "string",
-                  "null"
-                ]
-              },
-              "questionId": {
-                "type": [
-                  "string",
-                  "null"
-                ]
-              },
-              "response": {
-                "type": [
-                  "string",
-                  "null"
-                ]
-              },
-              "transcription": {
-                "type": [
-                  "string",
-                  "null"
-                ]
-              },
-              "transcriptionMetadata": true,
-              "type": {
-                "type": [
-                  "string",
-                  "null"
-                ]
-              },
-              "url": {
-                "type": [
-                  "string",
-                  "null"
-                ]
-              },
-              "waveform": {
-                "type": [
-                  "string",
-                  "null"
-                ]
-              }
-            },
-            "type": "object"
-          },
-          "ProfileName": {
-            "properties": {
-              "firstName": {
-                "type": "string"
-              },
-              "lastName": {
-                "default": null,
-                "type": [
-                  "string",
-                  "null"
-                ]
-              }
-            },
-            "required": [
-              "firstName"
-            ],
-            "type": "object"
-          }
-        },
         "properties": {
           "answers": {
             "default": [],
             "items": {
-              "$ref": "#/components/schemas/ProfileContent/$defs/ProfileAnswer"
+              "$ref": "#/components/schemas/ProfileAnswer"
             },
             "type": "array"
           },
           "name": {
-            "$ref": "#/components/schemas/ProfileContent/$defs/ProfileName"
+            "$ref": "#/components/schemas/ProfileName"
           },
           "photos": {
             "default": [],
             "items": {
-              "$ref": "#/components/schemas/ProfileContent/$defs/PhotoAsset"
+              "$ref": "#/components/schemas/PhotoAsset"
             },
             "type": "array"
           }
@@ -6641,315 +2553,23 @@
         "type": "object"
       },
       "ProfileContentContent": {
-        "$defs": {
-          "BoundingBox": {
-            "properties": {
-              "bottomRight": {
-                "$ref": "#/components/schemas/ProfileContentContent/$defs/Coordinate",
-                "default": {
-                  "x": 0.0,
-                  "y": 0.0
-                }
-              },
-              "topLeft": {
-                "$ref": "#/components/schemas/ProfileContentContent/$defs/Coordinate",
-                "default": {
-                  "x": 0.0,
-                  "y": 0.0
-                }
-              }
-            },
-            "type": "object"
-          },
-          "Coordinate": {
-            "properties": {
-              "x": {
-                "default": 0.0,
-                "format": "double",
-                "type": "number"
-              },
-              "y": {
-                "default": 0.0,
-                "format": "double",
-                "type": "number"
-              }
-            },
-            "type": "object"
-          },
-          "Feedback": {
-            "properties": {
-              "detail": {
-                "type": "string"
-              },
-              "evaluation": {
-                "type": "string"
-              },
-              "feedbackToken": {
-                "type": "string"
-              }
-            },
-            "required": [
-              "evaluation",
-              "detail",
-              "feedbackToken"
-            ],
-            "type": "object"
-          },
-          "PhotoAsset": {
-            "properties": {
-              "boundingBox": {
-                "anyOf": [
-                  {
-                    "$ref": "#/components/schemas/ProfileContentContent/$defs/BoundingBox"
-                  },
-                  {
-                    "type": "null"
-                  }
-                ]
-              },
-              "caption": {
-                "type": [
-                  "string",
-                  "null"
-                ]
-              },
-              "cdnId": {
-                "type": [
-                  "string",
-                  "null"
-                ]
-              },
-              "contentId": {
-                "type": [
-                  "string",
-                  "null"
-                ]
-              },
-              "height": {
-                "format": "int32",
-                "type": [
-                  "integer",
-                  "null"
-                ]
-              },
-              "id": {
-                "type": [
-                  "string",
-                  "null"
-                ]
-              },
-              "location": {
-                "type": [
-                  "string",
-                  "null"
-                ]
-              },
-              "pHash": {
-                "type": [
-                  "string",
-                  "null"
-                ]
-              },
-              "promptId": {
-                "type": [
-                  "string",
-                  "null"
-                ]
-              },
-              "selfieVerified": {
-                "type": [
-                  "boolean",
-                  "null"
-                ]
-              },
-              "source": {
-                "type": [
-                  "string",
-                  "null"
-                ]
-              },
-              "sourceId": {
-                "type": [
-                  "string",
-                  "null"
-                ]
-              },
-              "url": {
-                "type": "string"
-              },
-              "videoUrl": {
-                "type": [
-                  "string",
-                  "null"
-                ]
-              },
-              "width": {
-                "format": "int32",
-                "type": [
-                  "integer",
-                  "null"
-                ]
-              }
-            },
-            "required": [
-              "url"
-            ],
-            "type": "object"
-          },
-          "ProfileAnswer": {
-            "properties": {
-              "cdnId": {
-                "type": [
-                  "string",
-                  "null"
-                ]
-              },
-              "content": {
-                "type": [
-                  "string",
-                  "null"
-                ]
-              },
-              "contentId": {
-                "type": [
-                  "string",
-                  "null"
-                ]
-              },
-              "feedback": {
-                "anyOf": [
-                  {
-                    "$ref": "#/components/schemas/ProfileContentContent/$defs/Feedback"
-                  },
-                  {
-                    "type": "null"
-                  }
-                ]
-              },
-              "position": {
-                "format": "int32",
-                "type": [
-                  "integer",
-                  "null"
-                ]
-              },
-              "promptId": {
-                "type": [
-                  "string",
-                  "null"
-                ]
-              },
-              "questionId": {
-                "type": [
-                  "string",
-                  "null"
-                ]
-              },
-              "response": {
-                "type": [
-                  "string",
-                  "null"
-                ]
-              },
-              "transcription": {
-                "type": [
-                  "string",
-                  "null"
-                ]
-              },
-              "transcriptionMetadata": true,
-              "type": {
-                "type": [
-                  "string",
-                  "null"
-                ]
-              },
-              "url": {
-                "type": [
-                  "string",
-                  "null"
-                ]
-              },
-              "waveform": {
-                "type": [
-                  "string",
-                  "null"
-                ]
-              }
-            },
-            "type": "object"
-          },
-          "PromptPoll": {
-            "properties": {
-              "contentId": {
-                "type": "string"
-              },
-              "options": {
-                "items": {
-                  "type": "string"
-                },
-                "type": "array"
-              },
-              "questionId": {
-                "type": "string"
-              }
-            },
-            "required": [
-              "contentId",
-              "questionId",
-              "options"
-            ],
-            "type": "object"
-          },
-          "VideoPrompt": {
-            "properties": {
-              "boundingBox": {
-                "$ref": "#/components/schemas/ProfileContentContent/$defs/BoundingBox"
-              },
-              "cdnId": {
-                "type": "string"
-              },
-              "contentId": {
-                "type": "string"
-              },
-              "questionId": {
-                "type": "string"
-              },
-              "thumbnailUrl": {
-                "type": "string"
-              },
-              "videoUrl": {
-                "type": "string"
-              }
-            },
-            "required": [
-              "contentId",
-              "questionId",
-              "thumbnailUrl",
-              "videoUrl",
-              "cdnId",
-              "boundingBox"
-            ],
-            "type": "object"
-          }
-        },
         "properties": {
           "answers": {
             "items": {
-              "$ref": "#/components/schemas/ProfileContentContent/$defs/ProfileAnswer"
+              "$ref": "#/components/schemas/ProfileAnswer"
             },
             "type": "array"
           },
           "photos": {
             "items": {
-              "$ref": "#/components/schemas/ProfileContentContent/$defs/PhotoAsset"
+              "$ref": "#/components/schemas/PhotoAsset"
             },
             "type": "array"
           },
           "promptPoll": {
             "anyOf": [
               {
-                "$ref": "#/components/schemas/ProfileContentContent/$defs/PromptPoll"
+                "$ref": "#/components/schemas/PromptPoll"
               },
               {
                 "type": "null"
@@ -6960,7 +2580,7 @@
           "videoPrompt": {
             "anyOf": [
               {
-                "$ref": "#/components/schemas/ProfileContentContent/$defs/VideoPrompt"
+                "$ref": "#/components/schemas/VideoPrompt"
               },
               {
                 "type": "null"
@@ -6977,344 +2597,9 @@
         "type": "object"
       },
       "ProfileContentFull": {
-        "$defs": {
-          "BoundingBox": {
-            "properties": {
-              "bottomRight": {
-                "$ref": "#/components/schemas/ProfileContentFull/$defs/Coordinate",
-                "default": {
-                  "x": 0.0,
-                  "y": 0.0
-                }
-              },
-              "topLeft": {
-                "$ref": "#/components/schemas/ProfileContentFull/$defs/Coordinate",
-                "default": {
-                  "x": 0.0,
-                  "y": 0.0
-                }
-              }
-            },
-            "type": "object"
-          },
-          "Coordinate": {
-            "properties": {
-              "x": {
-                "default": 0.0,
-                "format": "double",
-                "type": "number"
-              },
-              "y": {
-                "default": 0.0,
-                "format": "double",
-                "type": "number"
-              }
-            },
-            "type": "object"
-          },
-          "Feedback": {
-            "properties": {
-              "detail": {
-                "type": "string"
-              },
-              "evaluation": {
-                "type": "string"
-              },
-              "feedbackToken": {
-                "type": "string"
-              }
-            },
-            "required": [
-              "evaluation",
-              "detail",
-              "feedbackToken"
-            ],
-            "type": "object"
-          },
-          "PhotoAsset": {
-            "properties": {
-              "boundingBox": {
-                "anyOf": [
-                  {
-                    "$ref": "#/components/schemas/ProfileContentFull/$defs/BoundingBox"
-                  },
-                  {
-                    "type": "null"
-                  }
-                ]
-              },
-              "caption": {
-                "type": [
-                  "string",
-                  "null"
-                ]
-              },
-              "cdnId": {
-                "type": [
-                  "string",
-                  "null"
-                ]
-              },
-              "contentId": {
-                "type": [
-                  "string",
-                  "null"
-                ]
-              },
-              "height": {
-                "format": "int32",
-                "type": [
-                  "integer",
-                  "null"
-                ]
-              },
-              "id": {
-                "type": [
-                  "string",
-                  "null"
-                ]
-              },
-              "location": {
-                "type": [
-                  "string",
-                  "null"
-                ]
-              },
-              "pHash": {
-                "type": [
-                  "string",
-                  "null"
-                ]
-              },
-              "promptId": {
-                "type": [
-                  "string",
-                  "null"
-                ]
-              },
-              "selfieVerified": {
-                "type": [
-                  "boolean",
-                  "null"
-                ]
-              },
-              "source": {
-                "type": [
-                  "string",
-                  "null"
-                ]
-              },
-              "sourceId": {
-                "type": [
-                  "string",
-                  "null"
-                ]
-              },
-              "url": {
-                "type": "string"
-              },
-              "videoUrl": {
-                "type": [
-                  "string",
-                  "null"
-                ]
-              },
-              "width": {
-                "format": "int32",
-                "type": [
-                  "integer",
-                  "null"
-                ]
-              }
-            },
-            "required": [
-              "url"
-            ],
-            "type": "object"
-          },
-          "ProfileAnswer": {
-            "properties": {
-              "cdnId": {
-                "type": [
-                  "string",
-                  "null"
-                ]
-              },
-              "content": {
-                "type": [
-                  "string",
-                  "null"
-                ]
-              },
-              "contentId": {
-                "type": [
-                  "string",
-                  "null"
-                ]
-              },
-              "feedback": {
-                "anyOf": [
-                  {
-                    "$ref": "#/components/schemas/ProfileContentFull/$defs/Feedback"
-                  },
-                  {
-                    "type": "null"
-                  }
-                ]
-              },
-              "position": {
-                "format": "int32",
-                "type": [
-                  "integer",
-                  "null"
-                ]
-              },
-              "promptId": {
-                "type": [
-                  "string",
-                  "null"
-                ]
-              },
-              "questionId": {
-                "type": [
-                  "string",
-                  "null"
-                ]
-              },
-              "response": {
-                "type": [
-                  "string",
-                  "null"
-                ]
-              },
-              "transcription": {
-                "type": [
-                  "string",
-                  "null"
-                ]
-              },
-              "transcriptionMetadata": true,
-              "type": {
-                "type": [
-                  "string",
-                  "null"
-                ]
-              },
-              "url": {
-                "type": [
-                  "string",
-                  "null"
-                ]
-              },
-              "waveform": {
-                "type": [
-                  "string",
-                  "null"
-                ]
-              }
-            },
-            "type": "object"
-          },
-          "ProfileContentContent": {
-            "properties": {
-              "answers": {
-                "items": {
-                  "$ref": "#/components/schemas/ProfileContentFull/$defs/ProfileAnswer"
-                },
-                "type": "array"
-              },
-              "photos": {
-                "items": {
-                  "$ref": "#/components/schemas/ProfileContentFull/$defs/PhotoAsset"
-                },
-                "type": "array"
-              },
-              "promptPoll": {
-                "anyOf": [
-                  {
-                    "$ref": "#/components/schemas/ProfileContentFull/$defs/PromptPoll"
-                  },
-                  {
-                    "type": "null"
-                  }
-                ],
-                "default": null
-              },
-              "videoPrompt": {
-                "anyOf": [
-                  {
-                    "$ref": "#/components/schemas/ProfileContentFull/$defs/VideoPrompt"
-                  },
-                  {
-                    "type": "null"
-                  }
-                ],
-                "default": null
-              }
-            },
-            "required": [
-              "photos",
-              "answers"
-            ],
-            "type": "object"
-          },
-          "PromptPoll": {
-            "properties": {
-              "contentId": {
-                "type": "string"
-              },
-              "options": {
-                "items": {
-                  "type": "string"
-                },
-                "type": "array"
-              },
-              "questionId": {
-                "type": "string"
-              }
-            },
-            "required": [
-              "contentId",
-              "questionId",
-              "options"
-            ],
-            "type": "object"
-          },
-          "VideoPrompt": {
-            "properties": {
-              "boundingBox": {
-                "$ref": "#/components/schemas/ProfileContentFull/$defs/BoundingBox"
-              },
-              "cdnId": {
-                "type": "string"
-              },
-              "contentId": {
-                "type": "string"
-              },
-              "questionId": {
-                "type": "string"
-              },
-              "thumbnailUrl": {
-                "type": "string"
-              },
-              "videoUrl": {
-                "type": "string"
-              }
-            },
-            "required": [
-              "contentId",
-              "questionId",
-              "thumbnailUrl",
-              "videoUrl",
-              "cdnId",
-              "boundingBox"
-            ],
-            "type": "object"
-          }
-        },
         "properties": {
           "content": {
-            "$ref": "#/components/schemas/ProfileContentFull/$defs/ProfileContentContent"
+            "$ref": "#/components/schemas/ProfileContentContent"
           },
           "userId": {
             "type": "string"
@@ -7347,351 +2632,11 @@
         "type": "object"
       },
       "ProfileUpdate": {
-        "$defs": {
-          "ChildrenStatus": {
-            "properties": {
-              "value": {
-                "$ref": "#/components/schemas/ProfileUpdate/$defs/ChildrenStatusProfile"
-              },
-              "visible": {
-                "type": "boolean"
-              }
-            },
-            "required": [
-              "value",
-              "visible"
-            ],
-            "type": "object"
-          },
-          "ChildrenStatusProfile": {
-            "enum": [
-              "PreferNotToSay",
-              "No",
-              "Yes"
-            ],
-            "type": "string"
-          },
-          "DatingIntention": {
-            "properties": {
-              "value": {
-                "$ref": "#/components/schemas/ProfileUpdate/$defs/DatingIntentionProfile"
-              },
-              "visible": {
-                "type": "boolean"
-              }
-            },
-            "required": [
-              "value",
-              "visible"
-            ],
-            "type": "object"
-          },
-          "DatingIntentionProfile": {
-            "enum": [
-              "PreferNotToSay",
-              "LifePartner",
-              "LongTermRelationship",
-              "LongTermOpenToShort",
-              "ShortTermOpenToLong",
-              "ShortTermRelationship",
-              "FiguringOutTheirDatingGoals"
-            ],
-            "type": "string"
-          },
-          "DrinkingStatus": {
-            "properties": {
-              "value": {
-                "$ref": "#/components/schemas/ProfileUpdate/$defs/DrinkingStatusProfile"
-              },
-              "visible": {
-                "type": "boolean"
-              }
-            },
-            "required": [
-              "value",
-              "visible"
-            ],
-            "type": "object"
-          },
-          "DrinkingStatusProfile": {
-            "enum": [
-              "PreferNotToSay",
-              "No",
-              "Yes",
-              "Sometimes"
-            ],
-            "type": "string"
-          },
-          "DrugStatus": {
-            "properties": {
-              "value": {
-                "$ref": "#/components/schemas/ProfileUpdate/$defs/DrugStatusProfile"
-              },
-              "visible": {
-                "type": "boolean"
-              }
-            },
-            "required": [
-              "value",
-              "visible"
-            ],
-            "type": "object"
-          },
-          "DrugStatusProfile": {
-            "enum": [
-              "PreferNotToSay",
-              "No",
-              "Yes",
-              "Sometimes"
-            ],
-            "type": "string"
-          },
-          "EducationAttainedProfile": {
-            "enum": [
-              "PreferNotToSay",
-              "HighSchool",
-              "TradeSchool",
-              "InCollege",
-              "Undergraduate",
-              "InGradSchool",
-              "Graduate"
-            ],
-            "type": "string"
-          },
-          "Ethnicities": {
-            "properties": {
-              "value": {
-                "items": {
-                  "$ref": "#/components/schemas/ProfileUpdate/$defs/EthnicityProfile"
-                },
-                "type": "array"
-              },
-              "visible": {
-                "type": "boolean"
-              }
-            },
-            "required": [
-              "value",
-              "visible"
-            ],
-            "type": "object"
-          },
-          "EthnicityProfile": {
-            "enum": [
-              "PreferNotToSay",
-              "AmericanIndian",
-              "BlackAfrican",
-              "EastAsian",
-              "Hispanic",
-              "MiddleEastern",
-              "PacificIslander",
-              "SouthAsian",
-              "White",
-              "Other"
-            ],
-            "type": "string"
-          },
-          "GenderEnum": {
-            "enum": [
-              "Man",
-              "Woman",
-              "NonBinary"
-            ],
-            "type": "string"
-          },
-          "Hometown": {
-            "properties": {
-              "value": {
-                "type": "string"
-              },
-              "visible": {
-                "type": "boolean"
-              }
-            },
-            "required": [
-              "value",
-              "visible"
-            ],
-            "type": "object"
-          },
-          "LanguagesSpoken": {
-            "properties": {
-              "value": {
-                "items": {
-                  "format": "int32",
-                  "type": "integer"
-                },
-                "type": "array"
-              },
-              "visible": {
-                "type": "boolean"
-              }
-            },
-            "required": [
-              "value",
-              "visible"
-            ],
-            "type": "object"
-          },
-          "MarijuanaStatus": {
-            "properties": {
-              "value": {
-                "$ref": "#/components/schemas/ProfileUpdate/$defs/MarijuanaStatusProfile"
-              },
-              "visible": {
-                "type": "boolean"
-              }
-            },
-            "required": [
-              "value",
-              "visible"
-            ],
-            "type": "object"
-          },
-          "MarijuanaStatusProfile": {
-            "enum": [
-              "PreferNotToSay",
-              "No",
-              "Yes",
-              "Sometimes",
-              "NoPreference"
-            ],
-            "type": "string"
-          },
-          "Politics": {
-            "properties": {
-              "value": {
-                "$ref": "#/components/schemas/ProfileUpdate/$defs/PoliticsProfile"
-              },
-              "visible": {
-                "type": "boolean"
-              }
-            },
-            "required": [
-              "value",
-              "visible"
-            ],
-            "type": "object"
-          },
-          "PoliticsProfile": {
-            "enum": [
-              "PreferNotToSay",
-              "Liberal",
-              "Moderate",
-              "Conservative",
-              "NotPolitical",
-              "Other"
-            ],
-            "type": "string"
-          },
-          "RelationshipTypeIds": {
-            "properties": {
-              "value": {
-                "items": {
-                  "$ref": "#/components/schemas/ProfileUpdate/$defs/RelationshipTypeProfile"
-                },
-                "type": "array"
-              },
-              "visible": {
-                "type": "boolean"
-              }
-            },
-            "required": [
-              "value",
-              "visible"
-            ],
-            "type": "object"
-          },
-          "RelationshipTypeProfile": {
-            "enum": [
-              "PreferNotToSay",
-              "Monogamy",
-              "EthicalNonMonogamy",
-              "FiguringOutTheirRelationshipType"
-            ],
-            "type": "string"
-          },
-          "Religion": {
-            "properties": {
-              "value": {
-                "items": {
-                  "$ref": "#/components/schemas/ProfileUpdate/$defs/ReligionProfile"
-                },
-                "type": "array"
-              },
-              "visible": {
-                "type": "boolean"
-              }
-            },
-            "required": [
-              "value",
-              "visible"
-            ],
-            "type": "object"
-          },
-          "ReligionProfile": {
-            "enum": [
-              "PreferNotToSay",
-              "Spiritual",
-              "Catholic",
-              "Christian",
-              "Hindu",
-              "Jewish",
-              "Muslim",
-              "Buddhist",
-              "Agnostic",
-              "Atheist",
-              "Other",
-              "Sikh"
-            ],
-            "type": "string"
-          },
-          "SmokingStatus": {
-            "properties": {
-              "value": {
-                "$ref": "#/components/schemas/ProfileUpdate/$defs/SmokingStatusProfile"
-              },
-              "visible": {
-                "type": "boolean"
-              }
-            },
-            "required": [
-              "value",
-              "visible"
-            ],
-            "type": "object"
-          },
-          "SmokingStatusProfile": {
-            "enum": [
-              "PreferNotToSay",
-              "No",
-              "Yes",
-              "Sometimes"
-            ],
-            "type": "string"
-          },
-          "Zodiac": {
-            "properties": {
-              "value": {
-                "format": "int32",
-                "type": "integer"
-              },
-              "visible": {
-                "type": "boolean"
-              }
-            },
-            "required": [
-              "value",
-              "visible"
-            ],
-            "type": "object"
-          }
-        },
         "properties": {
           "children": {
             "anyOf": [
               {
-                "$ref": "#/components/schemas/ProfileUpdate/$defs/ChildrenStatus"
+                "$ref": "#/components/schemas/ChildrenStatus"
               },
               {
                 "type": "null"
@@ -7701,7 +2646,7 @@
           "datingIntention": {
             "anyOf": [
               {
-                "$ref": "#/components/schemas/ProfileUpdate/$defs/DatingIntention"
+                "$ref": "#/components/schemas/DatingIntention"
               },
               {
                 "type": "null"
@@ -7711,7 +2656,7 @@
           "drinking": {
             "anyOf": [
               {
-                "$ref": "#/components/schemas/ProfileUpdate/$defs/DrinkingStatus"
+                "$ref": "#/components/schemas/DrinkingStatus"
               },
               {
                 "type": "null"
@@ -7721,7 +2666,7 @@
           "drugs": {
             "anyOf": [
               {
-                "$ref": "#/components/schemas/ProfileUpdate/$defs/DrugStatus"
+                "$ref": "#/components/schemas/DrugStatus"
               },
               {
                 "type": "null"
@@ -7731,7 +2676,7 @@
           "educationAttained": {
             "anyOf": [
               {
-                "$ref": "#/components/schemas/ProfileUpdate/$defs/EducationAttainedProfile"
+                "$ref": "#/components/schemas/EducationAttainedProfile"
               },
               {
                 "type": "null"
@@ -7741,7 +2686,7 @@
           "ethnicities": {
             "anyOf": [
               {
-                "$ref": "#/components/schemas/ProfileUpdate/$defs/Ethnicities"
+                "$ref": "#/components/schemas/Ethnicities"
               },
               {
                 "type": "null"
@@ -7751,7 +2696,7 @@
           "genderId": {
             "anyOf": [
               {
-                "$ref": "#/components/schemas/ProfileUpdate/$defs/GenderEnum"
+                "$ref": "#/components/schemas/GenderEnum"
               },
               {
                 "type": "null"
@@ -7768,7 +2713,7 @@
           "hometown": {
             "anyOf": [
               {
-                "$ref": "#/components/schemas/ProfileUpdate/$defs/Hometown"
+                "$ref": "#/components/schemas/Hometown"
               },
               {
                 "type": "null"
@@ -7778,7 +2723,7 @@
           "languagesSpoken": {
             "anyOf": [
               {
-                "$ref": "#/components/schemas/ProfileUpdate/$defs/LanguagesSpoken"
+                "$ref": "#/components/schemas/LanguagesSpoken"
               },
               {
                 "type": "null"
@@ -7788,7 +2733,7 @@
           "marijuana": {
             "anyOf": [
               {
-                "$ref": "#/components/schemas/ProfileUpdate/$defs/MarijuanaStatus"
+                "$ref": "#/components/schemas/MarijuanaStatus"
               },
               {
                 "type": "null"
@@ -7798,7 +2743,7 @@
           "politics": {
             "anyOf": [
               {
-                "$ref": "#/components/schemas/ProfileUpdate/$defs/Politics"
+                "$ref": "#/components/schemas/Politics"
               },
               {
                 "type": "null"
@@ -7808,7 +2753,7 @@
           "relationshipTypeIds": {
             "anyOf": [
               {
-                "$ref": "#/components/schemas/ProfileUpdate/$defs/RelationshipTypeIds"
+                "$ref": "#/components/schemas/RelationshipTypeIds"
               },
               {
                 "type": "null"
@@ -7818,7 +2763,7 @@
           "religions": {
             "anyOf": [
               {
-                "$ref": "#/components/schemas/ProfileUpdate/$defs/Religion"
+                "$ref": "#/components/schemas/Religion"
               },
               {
                 "type": "null"
@@ -7828,7 +2773,7 @@
           "smoking": {
             "anyOf": [
               {
-                "$ref": "#/components/schemas/ProfileUpdate/$defs/SmokingStatus"
+                "$ref": "#/components/schemas/SmokingStatus"
               },
               {
                 "type": "null"
@@ -7838,7 +2783,7 @@
           "zodiac": {
             "anyOf": [
               {
-                "$ref": "#/components/schemas/ProfileUpdate/$defs/Zodiac"
+                "$ref": "#/components/schemas/Zodiac"
               },
               {
                 "type": "null"
@@ -7850,351 +2795,11 @@
         "type": "object"
       },
       "ProfileUpdateRequest": {
-        "$defs": {
-          "ChildrenStatus": {
-            "properties": {
-              "value": {
-                "$ref": "#/components/schemas/ProfileUpdateRequest/$defs/ChildrenStatusProfile"
-              },
-              "visible": {
-                "type": "boolean"
-              }
-            },
-            "required": [
-              "value",
-              "visible"
-            ],
-            "type": "object"
-          },
-          "ChildrenStatusProfile": {
-            "enum": [
-              "PreferNotToSay",
-              "No",
-              "Yes"
-            ],
-            "type": "string"
-          },
-          "DatingIntention": {
-            "properties": {
-              "value": {
-                "$ref": "#/components/schemas/ProfileUpdateRequest/$defs/DatingIntentionProfile"
-              },
-              "visible": {
-                "type": "boolean"
-              }
-            },
-            "required": [
-              "value",
-              "visible"
-            ],
-            "type": "object"
-          },
-          "DatingIntentionProfile": {
-            "enum": [
-              "PreferNotToSay",
-              "LifePartner",
-              "LongTermRelationship",
-              "LongTermOpenToShort",
-              "ShortTermOpenToLong",
-              "ShortTermRelationship",
-              "FiguringOutTheirDatingGoals"
-            ],
-            "type": "string"
-          },
-          "DrinkingStatus": {
-            "properties": {
-              "value": {
-                "$ref": "#/components/schemas/ProfileUpdateRequest/$defs/DrinkingStatusProfile"
-              },
-              "visible": {
-                "type": "boolean"
-              }
-            },
-            "required": [
-              "value",
-              "visible"
-            ],
-            "type": "object"
-          },
-          "DrinkingStatusProfile": {
-            "enum": [
-              "PreferNotToSay",
-              "No",
-              "Yes",
-              "Sometimes"
-            ],
-            "type": "string"
-          },
-          "DrugStatus": {
-            "properties": {
-              "value": {
-                "$ref": "#/components/schemas/ProfileUpdateRequest/$defs/DrugStatusProfile"
-              },
-              "visible": {
-                "type": "boolean"
-              }
-            },
-            "required": [
-              "value",
-              "visible"
-            ],
-            "type": "object"
-          },
-          "DrugStatusProfile": {
-            "enum": [
-              "PreferNotToSay",
-              "No",
-              "Yes",
-              "Sometimes"
-            ],
-            "type": "string"
-          },
-          "EducationAttainedProfile": {
-            "enum": [
-              "PreferNotToSay",
-              "HighSchool",
-              "TradeSchool",
-              "InCollege",
-              "Undergraduate",
-              "InGradSchool",
-              "Graduate"
-            ],
-            "type": "string"
-          },
-          "Ethnicities": {
-            "properties": {
-              "value": {
-                "items": {
-                  "$ref": "#/components/schemas/ProfileUpdateRequest/$defs/EthnicityProfile"
-                },
-                "type": "array"
-              },
-              "visible": {
-                "type": "boolean"
-              }
-            },
-            "required": [
-              "value",
-              "visible"
-            ],
-            "type": "object"
-          },
-          "EthnicityProfile": {
-            "enum": [
-              "PreferNotToSay",
-              "AmericanIndian",
-              "BlackAfrican",
-              "EastAsian",
-              "Hispanic",
-              "MiddleEastern",
-              "PacificIslander",
-              "SouthAsian",
-              "White",
-              "Other"
-            ],
-            "type": "string"
-          },
-          "GenderEnum": {
-            "enum": [
-              "Man",
-              "Woman",
-              "NonBinary"
-            ],
-            "type": "string"
-          },
-          "Hometown": {
-            "properties": {
-              "value": {
-                "type": "string"
-              },
-              "visible": {
-                "type": "boolean"
-              }
-            },
-            "required": [
-              "value",
-              "visible"
-            ],
-            "type": "object"
-          },
-          "LanguagesSpoken": {
-            "properties": {
-              "value": {
-                "items": {
-                  "format": "int32",
-                  "type": "integer"
-                },
-                "type": "array"
-              },
-              "visible": {
-                "type": "boolean"
-              }
-            },
-            "required": [
-              "value",
-              "visible"
-            ],
-            "type": "object"
-          },
-          "MarijuanaStatus": {
-            "properties": {
-              "value": {
-                "$ref": "#/components/schemas/ProfileUpdateRequest/$defs/MarijuanaStatusProfile"
-              },
-              "visible": {
-                "type": "boolean"
-              }
-            },
-            "required": [
-              "value",
-              "visible"
-            ],
-            "type": "object"
-          },
-          "MarijuanaStatusProfile": {
-            "enum": [
-              "PreferNotToSay",
-              "No",
-              "Yes",
-              "Sometimes",
-              "NoPreference"
-            ],
-            "type": "string"
-          },
-          "Politics": {
-            "properties": {
-              "value": {
-                "$ref": "#/components/schemas/ProfileUpdateRequest/$defs/PoliticsProfile"
-              },
-              "visible": {
-                "type": "boolean"
-              }
-            },
-            "required": [
-              "value",
-              "visible"
-            ],
-            "type": "object"
-          },
-          "PoliticsProfile": {
-            "enum": [
-              "PreferNotToSay",
-              "Liberal",
-              "Moderate",
-              "Conservative",
-              "NotPolitical",
-              "Other"
-            ],
-            "type": "string"
-          },
-          "RelationshipTypeIds": {
-            "properties": {
-              "value": {
-                "items": {
-                  "$ref": "#/components/schemas/ProfileUpdateRequest/$defs/RelationshipTypeProfile"
-                },
-                "type": "array"
-              },
-              "visible": {
-                "type": "boolean"
-              }
-            },
-            "required": [
-              "value",
-              "visible"
-            ],
-            "type": "object"
-          },
-          "RelationshipTypeProfile": {
-            "enum": [
-              "PreferNotToSay",
-              "Monogamy",
-              "EthicalNonMonogamy",
-              "FiguringOutTheirRelationshipType"
-            ],
-            "type": "string"
-          },
-          "Religion": {
-            "properties": {
-              "value": {
-                "items": {
-                  "$ref": "#/components/schemas/ProfileUpdateRequest/$defs/ReligionProfile"
-                },
-                "type": "array"
-              },
-              "visible": {
-                "type": "boolean"
-              }
-            },
-            "required": [
-              "value",
-              "visible"
-            ],
-            "type": "object"
-          },
-          "ReligionProfile": {
-            "enum": [
-              "PreferNotToSay",
-              "Spiritual",
-              "Catholic",
-              "Christian",
-              "Hindu",
-              "Jewish",
-              "Muslim",
-              "Buddhist",
-              "Agnostic",
-              "Atheist",
-              "Other",
-              "Sikh"
-            ],
-            "type": "string"
-          },
-          "SmokingStatus": {
-            "properties": {
-              "value": {
-                "$ref": "#/components/schemas/ProfileUpdateRequest/$defs/SmokingStatusProfile"
-              },
-              "visible": {
-                "type": "boolean"
-              }
-            },
-            "required": [
-              "value",
-              "visible"
-            ],
-            "type": "object"
-          },
-          "SmokingStatusProfile": {
-            "enum": [
-              "PreferNotToSay",
-              "No",
-              "Yes",
-              "Sometimes"
-            ],
-            "type": "string"
-          },
-          "Zodiac": {
-            "properties": {
-              "value": {
-                "format": "int32",
-                "type": "integer"
-              },
-              "visible": {
-                "type": "boolean"
-              }
-            },
-            "required": [
-              "value",
-              "visible"
-            ],
-            "type": "object"
-          }
-        },
         "properties": {
           "children": {
             "anyOf": [
               {
-                "$ref": "#/components/schemas/ProfileUpdateRequest/$defs/ChildrenStatus"
+                "$ref": "#/components/schemas/ChildrenStatus"
               },
               {
                 "type": "null"
@@ -8204,7 +2809,7 @@
           "datingIntention": {
             "anyOf": [
               {
-                "$ref": "#/components/schemas/ProfileUpdateRequest/$defs/DatingIntention"
+                "$ref": "#/components/schemas/DatingIntention"
               },
               {
                 "type": "null"
@@ -8214,7 +2819,7 @@
           "drinking": {
             "anyOf": [
               {
-                "$ref": "#/components/schemas/ProfileUpdateRequest/$defs/DrinkingStatus"
+                "$ref": "#/components/schemas/DrinkingStatus"
               },
               {
                 "type": "null"
@@ -8224,7 +2829,7 @@
           "drugs": {
             "anyOf": [
               {
-                "$ref": "#/components/schemas/ProfileUpdateRequest/$defs/DrugStatus"
+                "$ref": "#/components/schemas/DrugStatus"
               },
               {
                 "type": "null"
@@ -8234,7 +2839,7 @@
           "educationAttained": {
             "anyOf": [
               {
-                "$ref": "#/components/schemas/ProfileUpdateRequest/$defs/EducationAttainedProfile"
+                "$ref": "#/components/schemas/EducationAttainedProfile"
               },
               {
                 "type": "null"
@@ -8244,7 +2849,7 @@
           "ethnicities": {
             "anyOf": [
               {
-                "$ref": "#/components/schemas/ProfileUpdateRequest/$defs/Ethnicities"
+                "$ref": "#/components/schemas/Ethnicities"
               },
               {
                 "type": "null"
@@ -8254,7 +2859,7 @@
           "genderId": {
             "anyOf": [
               {
-                "$ref": "#/components/schemas/ProfileUpdateRequest/$defs/GenderEnum"
+                "$ref": "#/components/schemas/GenderEnum"
               },
               {
                 "type": "null"
@@ -8271,7 +2876,7 @@
           "hometown": {
             "anyOf": [
               {
-                "$ref": "#/components/schemas/ProfileUpdateRequest/$defs/Hometown"
+                "$ref": "#/components/schemas/Hometown"
               },
               {
                 "type": "null"
@@ -8281,7 +2886,7 @@
           "languagesSpoken": {
             "anyOf": [
               {
-                "$ref": "#/components/schemas/ProfileUpdateRequest/$defs/LanguagesSpoken"
+                "$ref": "#/components/schemas/LanguagesSpoken"
               },
               {
                 "type": "null"
@@ -8291,7 +2896,7 @@
           "marijuana": {
             "anyOf": [
               {
-                "$ref": "#/components/schemas/ProfileUpdateRequest/$defs/MarijuanaStatus"
+                "$ref": "#/components/schemas/MarijuanaStatus"
               },
               {
                 "type": "null"
@@ -8301,7 +2906,7 @@
           "politics": {
             "anyOf": [
               {
-                "$ref": "#/components/schemas/ProfileUpdateRequest/$defs/Politics"
+                "$ref": "#/components/schemas/Politics"
               },
               {
                 "type": "null"
@@ -8311,7 +2916,7 @@
           "relationshipTypeIds": {
             "anyOf": [
               {
-                "$ref": "#/components/schemas/ProfileUpdateRequest/$defs/RelationshipTypeIds"
+                "$ref": "#/components/schemas/RelationshipTypeIds"
               },
               {
                 "type": "null"
@@ -8321,7 +2926,7 @@
           "religions": {
             "anyOf": [
               {
-                "$ref": "#/components/schemas/ProfileUpdateRequest/$defs/Religion"
+                "$ref": "#/components/schemas/Religion"
               },
               {
                 "type": "null"
@@ -8331,7 +2936,7 @@
           "smoking": {
             "anyOf": [
               {
-                "$ref": "#/components/schemas/ProfileUpdateRequest/$defs/SmokingStatus"
+                "$ref": "#/components/schemas/SmokingStatus"
               },
               {
                 "type": "null"
@@ -8341,7 +2946,7 @@
           "zodiac": {
             "anyOf": [
               {
-                "$ref": "#/components/schemas/ProfileUpdateRequest/$defs/Zodiac"
+                "$ref": "#/components/schemas/Zodiac"
               },
               {
                 "type": "null"
@@ -8353,19 +2958,6 @@
         "type": "object"
       },
       "Prompt": {
-        "$defs": {
-          "ContentType": {
-            "enum": [
-              "text",
-              "media",
-              "audio",
-              "video",
-              "voice",
-              "poll"
-            ],
-            "type": "string"
-          }
-        },
         "properties": {
           "categories": {
             "default": [],
@@ -8377,7 +2969,7 @@
           "contentTypes": {
             "default": [],
             "items": {
-              "$ref": "#/components/schemas/Prompt/$defs/ContentType"
+              "$ref": "#/components/schemas/ContentType"
             },
             "type": "array"
           },
@@ -8460,93 +3052,16 @@
         "type": "object"
       },
       "PromptsResponse": {
-        "$defs": {
-          "ContentType": {
-            "enum": [
-              "text",
-              "media",
-              "audio",
-              "video",
-              "voice",
-              "poll"
-            ],
-            "type": "string"
-          },
-          "Prompt": {
-            "properties": {
-              "categories": {
-                "default": [],
-                "items": {
-                  "type": "string"
-                },
-                "type": "array"
-              },
-              "contentTypes": {
-                "default": [],
-                "items": {
-                  "$ref": "#/components/schemas/PromptsResponse/$defs/ContentType"
-                },
-                "type": "array"
-              },
-              "id": {
-                "type": "string"
-              },
-              "isNew": {
-                "type": "boolean"
-              },
-              "isSelectable": {
-                "type": "boolean"
-              },
-              "placeholder": {
-                "default": "",
-                "type": "string"
-              },
-              "prompt": {
-                "type": "string"
-              }
-            },
-            "required": [
-              "id",
-              "prompt",
-              "isSelectable",
-              "isNew"
-            ],
-            "type": "object"
-          },
-          "PromptCategory": {
-            "properties": {
-              "isNew": {
-                "type": "boolean"
-              },
-              "isVisible": {
-                "type": "boolean"
-              },
-              "name": {
-                "type": "string"
-              },
-              "slug": {
-                "type": "string"
-              }
-            },
-            "required": [
-              "name",
-              "slug",
-              "isVisible",
-              "isNew"
-            ],
-            "type": "object"
-          }
-        },
         "properties": {
           "categories": {
             "items": {
-              "$ref": "#/components/schemas/PromptsResponse/$defs/PromptCategory"
+              "$ref": "#/components/schemas/PromptCategory"
             },
             "type": "array"
           },
           "prompts": {
             "items": {
-              "$ref": "#/components/schemas/PromptsResponse/$defs/Prompt"
+              "$ref": "#/components/schemas/Prompt"
             },
             "type": "array"
           }
@@ -8558,6 +3073,25 @@
         "title": "PromptsResponse",
         "type": "object"
       },
+      "Pronouns": {
+        "properties": {
+          "value": {
+            "items": {
+              "format": "int32",
+              "type": "integer"
+            },
+            "type": "array"
+          },
+          "visible": {
+            "type": "boolean"
+          }
+        },
+        "required": [
+          "value",
+          "visible"
+        ],
+        "type": "object"
+      },
       "PublicContentResponse": {
         "items": {
           "$ref": "#/components/schemas/ProfileContentFull"
@@ -8565,89 +3099,6 @@
         "type": "array"
       },
       "PublicProfile": {
-        "$defs": {
-          "EducationAttainedProfile": {
-            "enum": [
-              "PreferNotToSay",
-              "HighSchool",
-              "TradeSchool",
-              "InCollege",
-              "Undergraduate",
-              "InGradSchool",
-              "Graduate"
-            ],
-            "type": "string"
-          },
-          "GenderEnum": {
-            "enum": [
-              "Man",
-              "Woman",
-              "NonBinary"
-            ],
-            "type": "string"
-          },
-          "Location": {
-            "properties": {
-              "adminArea1Long": {
-                "type": [
-                  "string",
-                  "null"
-                ]
-              },
-              "adminArea1Short": {
-                "type": [
-                  "string",
-                  "null"
-                ]
-              },
-              "adminArea2": {
-                "type": [
-                  "string",
-                  "null"
-                ]
-              },
-              "countryShort": {
-                "type": [
-                  "string",
-                  "null"
-                ]
-              },
-              "latitude": {
-                "format": "double",
-                "type": [
-                  "number",
-                  "null"
-                ]
-              },
-              "longitude": {
-                "format": "double",
-                "type": [
-                  "number",
-                  "null"
-                ]
-              },
-              "metroArea": {
-                "type": [
-                  "string",
-                  "null"
-                ]
-              },
-              "metroAreaV2": {
-                "type": [
-                  "string",
-                  "null"
-                ]
-              },
-              "name": {
-                "type": "string"
-              }
-            },
-            "required": [
-              "name"
-            ],
-            "type": "object"
-          }
-        },
         "properties": {
           "age": {
             "format": "int32",
@@ -8712,7 +3163,7 @@
           "educationAttained": {
             "anyOf": [
               {
-                "$ref": "#/components/schemas/PublicProfile/$defs/EducationAttainedProfile"
+                "$ref": "#/components/schemas/EducationAttainedProfile"
               },
               {
                 "type": "null"
@@ -8775,7 +3226,7 @@
           "genderId": {
             "anyOf": [
               {
-                "$ref": "#/components/schemas/PublicProfile/$defs/GenderEnum"
+                "$ref": "#/components/schemas/GenderEnum"
               },
               {
                 "type": "null"
@@ -8838,7 +3289,7 @@
             ]
           },
           "location": {
-            "$ref": "#/components/schemas/PublicProfile/$defs/Location"
+            "$ref": "#/components/schemas/Location"
           },
           "marijuana": {
             "format": "int32",
@@ -8957,394 +3408,9 @@
         "type": "array"
       },
       "PublicUserProfile": {
-        "$defs": {
-          "EducationAttainedProfile": {
-            "enum": [
-              "PreferNotToSay",
-              "HighSchool",
-              "TradeSchool",
-              "InCollege",
-              "Undergraduate",
-              "InGradSchool",
-              "Graduate"
-            ],
-            "type": "string"
-          },
-          "GenderEnum": {
-            "enum": [
-              "Man",
-              "Woman",
-              "NonBinary"
-            ],
-            "type": "string"
-          },
-          "Location": {
-            "properties": {
-              "adminArea1Long": {
-                "type": [
-                  "string",
-                  "null"
-                ]
-              },
-              "adminArea1Short": {
-                "type": [
-                  "string",
-                  "null"
-                ]
-              },
-              "adminArea2": {
-                "type": [
-                  "string",
-                  "null"
-                ]
-              },
-              "countryShort": {
-                "type": [
-                  "string",
-                  "null"
-                ]
-              },
-              "latitude": {
-                "format": "double",
-                "type": [
-                  "number",
-                  "null"
-                ]
-              },
-              "longitude": {
-                "format": "double",
-                "type": [
-                  "number",
-                  "null"
-                ]
-              },
-              "metroArea": {
-                "type": [
-                  "string",
-                  "null"
-                ]
-              },
-              "metroAreaV2": {
-                "type": [
-                  "string",
-                  "null"
-                ]
-              },
-              "name": {
-                "type": "string"
-              }
-            },
-            "required": [
-              "name"
-            ],
-            "type": "object"
-          },
-          "PublicProfile": {
-            "properties": {
-              "age": {
-                "format": "int32",
-                "type": [
-                  "integer",
-                  "null"
-                ]
-              },
-              "birthday": {
-                "type": [
-                  "string",
-                  "null"
-                ]
-              },
-              "children": {
-                "format": "int32",
-                "type": [
-                  "integer",
-                  "null"
-                ]
-              },
-              "covidVax": {
-                "format": "int32",
-                "type": [
-                  "integer",
-                  "null"
-                ]
-              },
-              "datingIntention": {
-                "format": "int32",
-                "type": [
-                  "integer",
-                  "null"
-                ]
-              },
-              "datingIntentionText": {
-                "type": [
-                  "string",
-                  "null"
-                ]
-              },
-              "didJustJoin": {
-                "type": [
-                  "boolean",
-                  "null"
-                ]
-              },
-              "drinking": {
-                "format": "int32",
-                "type": [
-                  "integer",
-                  "null"
-                ]
-              },
-              "drugs": {
-                "format": "int32",
-                "type": [
-                  "integer",
-                  "null"
-                ]
-              },
-              "educationAttained": {
-                "anyOf": [
-                  {
-                    "$ref": "#/components/schemas/PublicUserProfile/$defs/EducationAttainedProfile"
-                  },
-                  {
-                    "type": "null"
-                  }
-                ]
-              },
-              "educations": {
-                "items": {
-                  "type": "string"
-                },
-                "type": [
-                  "array",
-                  "null"
-                ]
-              },
-              "email": {
-                "type": [
-                  "string",
-                  "null"
-                ]
-              },
-              "emailVerified": {
-                "type": [
-                  "boolean",
-                  "null"
-                ]
-              },
-              "ethnicities": {
-                "items": {
-                  "format": "int32",
-                  "type": "integer"
-                },
-                "type": [
-                  "array",
-                  "null"
-                ]
-              },
-              "ethnicitiesText": {
-                "type": [
-                  "string",
-                  "null"
-                ]
-              },
-              "familyPlans": {
-                "format": "int32",
-                "type": [
-                  "integer",
-                  "null"
-                ]
-              },
-              "firstCompletedDate": {
-                "type": [
-                  "string",
-                  "null"
-                ]
-              },
-              "firstName": {
-                "type": "string"
-              },
-              "genderId": {
-                "anyOf": [
-                  {
-                    "$ref": "#/components/schemas/PublicUserProfile/$defs/GenderEnum"
-                  },
-                  {
-                    "type": "null"
-                  }
-                ]
-              },
-              "genderIdentity": {
-                "type": [
-                  "string",
-                  "null"
-                ]
-              },
-              "genderIdentityId": {
-                "format": "int32",
-                "type": [
-                  "integer",
-                  "null"
-                ]
-              },
-              "height": {
-                "format": "int32",
-                "type": [
-                  "integer",
-                  "null"
-                ]
-              },
-              "hometown": {
-                "type": [
-                  "string",
-                  "null"
-                ]
-              },
-              "jobTitle": {
-                "type": [
-                  "string",
-                  "null"
-                ]
-              },
-              "languagesSpoken": {
-                "items": {
-                  "format": "int32",
-                  "type": "integer"
-                },
-                "type": [
-                  "array",
-                  "null"
-                ]
-              },
-              "lastActiveStatusId": {
-                "format": "int32",
-                "type": [
-                  "integer",
-                  "null"
-                ]
-              },
-              "lastName": {
-                "type": [
-                  "string",
-                  "null"
-                ]
-              },
-              "location": {
-                "$ref": "#/components/schemas/PublicUserProfile/$defs/Location"
-              },
-              "marijuana": {
-                "format": "int32",
-                "type": [
-                  "integer",
-                  "null"
-                ]
-              },
-              "pets": {
-                "items": {
-                  "format": "int32",
-                  "type": "integer"
-                },
-                "type": [
-                  "array",
-                  "null"
-                ]
-              },
-              "phone": {
-                "type": [
-                  "string",
-                  "null"
-                ]
-              },
-              "politics": {
-                "format": "int32",
-                "type": [
-                  "integer",
-                  "null"
-                ]
-              },
-              "pronouns": {
-                "items": {
-                  "format": "int32",
-                  "type": "integer"
-                },
-                "type": [
-                  "array",
-                  "null"
-                ]
-              },
-              "relationshipTypeIds": {
-                "items": {
-                  "format": "int32",
-                  "type": "integer"
-                },
-                "type": [
-                  "array",
-                  "null"
-                ]
-              },
-              "relationshipTypesText": {
-                "type": [
-                  "string",
-                  "null"
-                ]
-              },
-              "religions": {
-                "items": {
-                  "format": "int32",
-                  "type": "integer"
-                },
-                "type": [
-                  "array",
-                  "null"
-                ]
-              },
-              "selfieVerified": {
-                "type": [
-                  "boolean",
-                  "null"
-                ]
-              },
-              "sexualOrientations": {
-                "items": {
-                  "format": "int32",
-                  "type": "integer"
-                },
-                "type": [
-                  "array",
-                  "null"
-                ]
-              },
-              "smoking": {
-                "format": "int32",
-                "type": [
-                  "integer",
-                  "null"
-                ]
-              },
-              "works": {
-                "type": [
-                  "string",
-                  "null"
-                ]
-              },
-              "zodiac": {
-                "format": "int32",
-                "type": [
-                  "integer",
-                  "null"
-                ]
-              }
-            },
-            "required": [
-              "firstName",
-              "location"
-            ],
-            "type": "object"
-          }
-        },
         "properties": {
           "profile": {
-            "$ref": "#/components/schemas/PublicUserProfile/$defs/PublicProfile"
+            "$ref": "#/components/schemas/PublicProfile"
           },
           "userId": {
             "type": "string"
@@ -9392,81 +3458,6 @@
         "type": "object"
       },
       "RateInput": {
-        "$defs": {
-          "BoundingBox": {
-            "properties": {
-              "bottomRight": {
-                "$ref": "#/components/schemas/RateInput/$defs/Coordinate",
-                "default": {
-                  "x": 0.0,
-                  "y": 0.0
-                }
-              },
-              "topLeft": {
-                "$ref": "#/components/schemas/RateInput/$defs/Coordinate",
-                "default": {
-                  "x": 0.0,
-                  "y": 0.0
-                }
-              }
-            },
-            "type": "object"
-          },
-          "Coordinate": {
-            "properties": {
-              "x": {
-                "default": 0.0,
-                "format": "double",
-                "type": "number"
-              },
-              "y": {
-                "default": 0.0,
-                "format": "double",
-                "type": "number"
-              }
-            },
-            "type": "object"
-          },
-          "PhotoAssetInput": {
-            "properties": {
-              "boundingBox": {
-                "anyOf": [
-                  {
-                    "$ref": "#/components/schemas/RateInput/$defs/BoundingBox"
-                  },
-                  {
-                    "type": "null"
-                  }
-                ]
-              },
-              "cdnId": {
-                "type": [
-                  "string",
-                  "null"
-                ]
-              },
-              "contentId": {
-                "type": [
-                  "string",
-                  "null"
-                ]
-              },
-              "selfieVerified": {
-                "type": [
-                  "boolean",
-                  "null"
-                ]
-              },
-              "url": {
-                "type": "string"
-              }
-            },
-            "required": [
-              "url"
-            ],
-            "type": "object"
-          }
-        },
         "properties": {
           "answerText": {
             "default": null,
@@ -9499,7 +3490,7 @@
           "photo": {
             "anyOf": [
               {
-                "$ref": "#/components/schemas/RateInput/$defs/PhotoAssetInput"
+                "$ref": "#/components/schemas/PhotoAssetInput"
               },
               {
                 "type": "null"
@@ -9536,26 +3527,11 @@
         "type": "object"
       },
       "RatePayload": {
-        "$defs": {
-          "RateContentPayload": {
-            "properties": {
-              "comment": {
-                "type": [
-                  "string",
-                  "null"
-                ]
-              },
-              "photo": true,
-              "prompt": true
-            },
-            "type": "object"
-          }
-        },
         "properties": {
           "content": {
             "anyOf": [
               {
-                "$ref": "#/components/schemas/RatePayload/$defs/RateContentPayload"
+                "$ref": "#/components/schemas/RateContentPayload"
               },
               {
                 "type": "null"
@@ -9653,33 +3629,11 @@
         "type": "object"
       },
       "RateRespondResponse": {
-        "$defs": {
-          "LikeLimit": {
-            "properties": {
-              "likes": {
-                "format": "int32",
-                "type": "integer"
-              },
-              "superlikes": {
-                "default": null,
-                "format": "int32",
-                "type": [
-                  "integer",
-                  "null"
-                ]
-              }
-            },
-            "required": [
-              "likes"
-            ],
-            "type": "object"
-          }
-        },
         "properties": {
           "limit": {
             "anyOf": [
               {
-                "$ref": "#/components/schemas/RateRespondResponse/$defs/LikeLimit"
+                "$ref": "#/components/schemas/LikeLimit"
               },
               {
                 "type": "null"
@@ -9720,48 +3674,6 @@
         "type": "object"
       },
       "RecommendationsFeed": {
-        "$defs": {
-          "RecommendationSubject": {
-            "properties": {
-              "origin": {
-                "default": null,
-                "type": [
-                  "string",
-                  "null"
-                ]
-              },
-              "ratingToken": {
-                "type": "string"
-              },
-              "subjectId": {
-                "type": "string"
-              }
-            },
-            "required": [
-              "subjectId",
-              "ratingToken"
-            ],
-            "type": "object"
-          },
-          "RecommendationsPreview": {
-            "properties": {
-              "permission": {
-                "type": "string"
-              },
-              "subjects": {
-                "items": {
-                  "$ref": "#/components/schemas/RecommendationsFeed/$defs/RecommendationSubject"
-                },
-                "type": "array"
-              }
-            },
-            "required": [
-              "subjects",
-              "permission"
-            ],
-            "type": "object"
-          }
-        },
         "properties": {
           "id": {
             "format": "int32",
@@ -9780,7 +3692,7 @@
           "preview": {
             "anyOf": [
               {
-                "$ref": "#/components/schemas/RecommendationsFeed/$defs/RecommendationsPreview"
+                "$ref": "#/components/schemas/RecommendationsPreview"
               },
               {
                 "type": "null"
@@ -9790,7 +3702,7 @@
           },
           "subjects": {
             "items": {
-              "$ref": "#/components/schemas/RecommendationsFeed/$defs/RecommendationSubject"
+              "$ref": "#/components/schemas/RecommendationSubject"
             },
             "type": "array"
           }
@@ -9804,37 +3716,13 @@
         "type": "object"
       },
       "RecommendationsPreview": {
-        "$defs": {
-          "RecommendationSubject": {
-            "properties": {
-              "origin": {
-                "default": null,
-                "type": [
-                  "string",
-                  "null"
-                ]
-              },
-              "ratingToken": {
-                "type": "string"
-              },
-              "subjectId": {
-                "type": "string"
-              }
-            },
-            "required": [
-              "subjectId",
-              "ratingToken"
-            ],
-            "type": "object"
-          }
-        },
         "properties": {
           "permission": {
             "type": "string"
           },
           "subjects": {
             "items": {
-              "$ref": "#/components/schemas/RecommendationsPreview/$defs/RecommendationSubject"
+              "$ref": "#/components/schemas/RecommendationSubject"
             },
             "type": "array"
           }
@@ -9862,113 +3750,11 @@
         "type": "object"
       },
       "RecommendationsResponse": {
-        "$defs": {
-          "ActivePill": {
-            "properties": {
-              "id": {
-                "type": "string"
-              },
-              "permission": {
-                "type": "string"
-              },
-              "pillType": {
-                "type": "string"
-              }
-            },
-            "required": [
-              "pillType",
-              "permission",
-              "id"
-            ],
-            "type": "object"
-          },
-          "RecommendationSubject": {
-            "properties": {
-              "origin": {
-                "default": null,
-                "type": [
-                  "string",
-                  "null"
-                ]
-              },
-              "ratingToken": {
-                "type": "string"
-              },
-              "subjectId": {
-                "type": "string"
-              }
-            },
-            "required": [
-              "subjectId",
-              "ratingToken"
-            ],
-            "type": "object"
-          },
-          "RecommendationsFeed": {
-            "properties": {
-              "id": {
-                "format": "int32",
-                "type": "integer"
-              },
-              "origin": {
-                "type": "string"
-              },
-              "permission": {
-                "default": null,
-                "type": [
-                  "string",
-                  "null"
-                ]
-              },
-              "preview": {
-                "anyOf": [
-                  {
-                    "$ref": "#/components/schemas/RecommendationsResponse/$defs/RecommendationsPreview"
-                  },
-                  {
-                    "type": "null"
-                  }
-                ],
-                "default": null
-              },
-              "subjects": {
-                "items": {
-                  "$ref": "#/components/schemas/RecommendationsResponse/$defs/RecommendationSubject"
-                },
-                "type": "array"
-              }
-            },
-            "required": [
-              "id",
-              "origin",
-              "subjects"
-            ],
-            "type": "object"
-          },
-          "RecommendationsPreview": {
-            "properties": {
-              "permission": {
-                "type": "string"
-              },
-              "subjects": {
-                "items": {
-                  "$ref": "#/components/schemas/RecommendationsResponse/$defs/RecommendationSubject"
-                },
-                "type": "array"
-              }
-            },
-            "required": [
-              "subjects",
-              "permission"
-            ],
-            "type": "object"
-          }
-        },
         "properties": {
           "activePills": {
             "default": null,
             "items": {
-              "$ref": "#/components/schemas/RecommendationsResponse/$defs/ActivePill"
+              "$ref": "#/components/schemas/ActivePill"
             },
             "type": [
               "array",
@@ -9980,7 +3766,7 @@
           },
           "feeds": {
             "items": {
-              "$ref": "#/components/schemas/RecommendationsResponse/$defs/RecommendationsFeed"
+              "$ref": "#/components/schemas/RecommendationsFeed"
             },
             "type": "array"
           }
@@ -10005,341 +3791,98 @@
         "title": "RecsV2Params",
         "type": "object"
       },
-      "SelfContentResponse": {
-        "$defs": {
-          "BoundingBox": {
-            "properties": {
-              "bottomRight": {
-                "$ref": "#/components/schemas/SelfContentResponse/$defs/Coordinate",
-                "default": {
-                  "x": 0.0,
-                  "y": 0.0
-                }
-              },
-              "topLeft": {
-                "$ref": "#/components/schemas/SelfContentResponse/$defs/Coordinate",
-                "default": {
-                  "x": 0.0,
-                  "y": 0.0
-                }
-              }
+      "RelationshipTypeIds": {
+        "properties": {
+          "value": {
+            "items": {
+              "$ref": "#/components/schemas/RelationshipTypeProfile"
             },
-            "type": "object"
+            "type": "array"
           },
-          "ContentData": {
-            "properties": {
-              "answers": {
-                "default": [],
-                "items": {
-                  "$ref": "#/components/schemas/SelfContentResponse/$defs/ProfileAnswer"
-                },
-                "type": "array"
-              },
-              "photos": {
-                "default": [],
-                "items": {
-                  "$ref": "#/components/schemas/SelfContentResponse/$defs/PhotoAsset"
-                },
-                "type": "array"
-              },
-              "promptPoll": {
-                "anyOf": [
-                  {
-                    "$ref": "#/components/schemas/SelfContentResponse/$defs/PromptPoll"
-                  },
-                  {
-                    "type": "null"
-                  }
-                ]
-              },
-              "videoPrompt": {
-                "anyOf": [
-                  {
-                    "$ref": "#/components/schemas/SelfContentResponse/$defs/VideoPrompt"
-                  },
-                  {
-                    "type": "null"
-                  }
-                ]
-              }
-            },
-            "type": "object"
-          },
-          "Coordinate": {
-            "properties": {
-              "x": {
-                "default": 0.0,
-                "format": "double",
-                "type": "number"
-              },
-              "y": {
-                "default": 0.0,
-                "format": "double",
-                "type": "number"
-              }
-            },
-            "type": "object"
-          },
-          "Feedback": {
-            "properties": {
-              "detail": {
-                "type": "string"
-              },
-              "evaluation": {
-                "type": "string"
-              },
-              "feedbackToken": {
-                "type": "string"
-              }
-            },
-            "required": [
-              "evaluation",
-              "detail",
-              "feedbackToken"
-            ],
-            "type": "object"
-          },
-          "PhotoAsset": {
-            "properties": {
-              "boundingBox": {
-                "anyOf": [
-                  {
-                    "$ref": "#/components/schemas/SelfContentResponse/$defs/BoundingBox"
-                  },
-                  {
-                    "type": "null"
-                  }
-                ]
-              },
-              "caption": {
-                "type": [
-                  "string",
-                  "null"
-                ]
-              },
-              "cdnId": {
-                "type": [
-                  "string",
-                  "null"
-                ]
-              },
-              "contentId": {
-                "type": [
-                  "string",
-                  "null"
-                ]
-              },
-              "height": {
-                "format": "int32",
-                "type": [
-                  "integer",
-                  "null"
-                ]
-              },
-              "id": {
-                "type": [
-                  "string",
-                  "null"
-                ]
-              },
-              "location": {
-                "type": [
-                  "string",
-                  "null"
-                ]
-              },
-              "pHash": {
-                "type": [
-                  "string",
-                  "null"
-                ]
-              },
-              "promptId": {
-                "type": [
-                  "string",
-                  "null"
-                ]
-              },
-              "selfieVerified": {
-                "type": [
-                  "boolean",
-                  "null"
-                ]
-              },
-              "source": {
-                "type": [
-                  "string",
-                  "null"
-                ]
-              },
-              "sourceId": {
-                "type": [
-                  "string",
-                  "null"
-                ]
-              },
-              "url": {
-                "type": "string"
-              },
-              "videoUrl": {
-                "type": [
-                  "string",
-                  "null"
-                ]
-              },
-              "width": {
-                "format": "int32",
-                "type": [
-                  "integer",
-                  "null"
-                ]
-              }
-            },
-            "required": [
-              "url"
-            ],
-            "type": "object"
-          },
-          "ProfileAnswer": {
-            "properties": {
-              "cdnId": {
-                "type": [
-                  "string",
-                  "null"
-                ]
-              },
-              "content": {
-                "type": [
-                  "string",
-                  "null"
-                ]
-              },
-              "contentId": {
-                "type": [
-                  "string",
-                  "null"
-                ]
-              },
-              "feedback": {
-                "anyOf": [
-                  {
-                    "$ref": "#/components/schemas/SelfContentResponse/$defs/Feedback"
-                  },
-                  {
-                    "type": "null"
-                  }
-                ]
-              },
-              "position": {
-                "format": "int32",
-                "type": [
-                  "integer",
-                  "null"
-                ]
-              },
-              "promptId": {
-                "type": [
-                  "string",
-                  "null"
-                ]
-              },
-              "questionId": {
-                "type": [
-                  "string",
-                  "null"
-                ]
-              },
-              "response": {
-                "type": [
-                  "string",
-                  "null"
-                ]
-              },
-              "transcription": {
-                "type": [
-                  "string",
-                  "null"
-                ]
-              },
-              "transcriptionMetadata": true,
-              "type": {
-                "type": [
-                  "string",
-                  "null"
-                ]
-              },
-              "url": {
-                "type": [
-                  "string",
-                  "null"
-                ]
-              },
-              "waveform": {
-                "type": [
-                  "string",
-                  "null"
-                ]
-              }
-            },
-            "type": "object"
-          },
-          "PromptPoll": {
-            "properties": {
-              "contentId": {
-                "type": "string"
-              },
-              "options": {
-                "items": {
-                  "type": "string"
-                },
-                "type": "array"
-              },
-              "questionId": {
-                "type": "string"
-              }
-            },
-            "required": [
-              "contentId",
-              "questionId",
-              "options"
-            ],
-            "type": "object"
-          },
-          "VideoPrompt": {
-            "properties": {
-              "boundingBox": {
-                "$ref": "#/components/schemas/SelfContentResponse/$defs/BoundingBox"
-              },
-              "cdnId": {
-                "type": "string"
-              },
-              "contentId": {
-                "type": "string"
-              },
-              "questionId": {
-                "type": "string"
-              },
-              "thumbnailUrl": {
-                "type": "string"
-              },
-              "videoUrl": {
-                "type": "string"
-              }
-            },
-            "required": [
-              "contentId",
-              "questionId",
-              "thumbnailUrl",
-              "videoUrl",
-              "cdnId",
-              "boundingBox"
-            ],
-            "type": "object"
+          "visible": {
+            "type": "boolean"
           }
         },
+        "required": [
+          "value",
+          "visible"
+        ],
+        "type": "object"
+      },
+      "RelationshipTypePreference": {
+        "enum": [
+          "OpenToAll",
+          "Monogamy",
+          "EthicalNonMonogamy",
+          "FiguringOutTheirRelationshipType"
+        ],
+        "type": "string"
+      },
+      "RelationshipTypeProfile": {
+        "enum": [
+          "PreferNotToSay",
+          "Monogamy",
+          "EthicalNonMonogamy",
+          "FiguringOutTheirRelationshipType"
+        ],
+        "type": "string"
+      },
+      "Religion": {
+        "properties": {
+          "value": {
+            "items": {
+              "$ref": "#/components/schemas/ReligionProfile"
+            },
+            "type": "array"
+          },
+          "visible": {
+            "type": "boolean"
+          }
+        },
+        "required": [
+          "value",
+          "visible"
+        ],
+        "type": "object"
+      },
+      "ReligionPreference": {
+        "enum": [
+          "OpenToAll",
+          "Spiritual",
+          "Catholic",
+          "Christian",
+          "Hindu",
+          "Jewish",
+          "Muslim",
+          "Buddhist",
+          "Agnostic",
+          "Atheist",
+          "Other",
+          "Sikh"
+        ],
+        "type": "string"
+      },
+      "ReligionProfile": {
+        "enum": [
+          "PreferNotToSay",
+          "Spiritual",
+          "Catholic",
+          "Christian",
+          "Hindu",
+          "Jewish",
+          "Muslim",
+          "Buddhist",
+          "Agnostic",
+          "Atheist",
+          "Other",
+          "Sikh"
+        ],
+        "type": "string"
+      },
+      "SelfContentResponse": {
         "properties": {
           "content": {
-            "$ref": "#/components/schemas/SelfContentResponse/$defs/ContentData"
+            "$ref": "#/components/schemas/ContentData"
           }
         },
         "required": [
@@ -10349,1140 +3892,6 @@
         "type": "object"
       },
       "SelfProfileResponse": {
-        "$defs": {
-          "BoundingBox": {
-            "properties": {
-              "bottomRight": {
-                "$ref": "#/components/schemas/SelfProfileResponse/$defs/Coordinate",
-                "default": {
-                  "x": 0.0,
-                  "y": 0.0
-                }
-              },
-              "topLeft": {
-                "$ref": "#/components/schemas/SelfProfileResponse/$defs/Coordinate",
-                "default": {
-                  "x": 0.0,
-                  "y": 0.0
-                }
-              }
-            },
-            "type": "object"
-          },
-          "ChildrenStatus": {
-            "properties": {
-              "value": {
-                "$ref": "#/components/schemas/SelfProfileResponse/$defs/ChildrenStatusProfile"
-              },
-              "visible": {
-                "type": "boolean"
-              }
-            },
-            "required": [
-              "value",
-              "visible"
-            ],
-            "type": "object"
-          },
-          "ChildrenStatusProfile": {
-            "enum": [
-              "PreferNotToSay",
-              "No",
-              "Yes"
-            ],
-            "type": "string"
-          },
-          "Coordinate": {
-            "properties": {
-              "x": {
-                "default": 0.0,
-                "format": "double",
-                "type": "number"
-              },
-              "y": {
-                "default": 0.0,
-                "format": "double",
-                "type": "number"
-              }
-            },
-            "type": "object"
-          },
-          "DatingIntention": {
-            "properties": {
-              "value": {
-                "$ref": "#/components/schemas/SelfProfileResponse/$defs/DatingIntentionProfile"
-              },
-              "visible": {
-                "type": "boolean"
-              }
-            },
-            "required": [
-              "value",
-              "visible"
-            ],
-            "type": "object"
-          },
-          "DatingIntentionProfile": {
-            "enum": [
-              "PreferNotToSay",
-              "LifePartner",
-              "LongTermRelationship",
-              "LongTermOpenToShort",
-              "ShortTermOpenToLong",
-              "ShortTermRelationship",
-              "FiguringOutTheirDatingGoals"
-            ],
-            "type": "string"
-          },
-          "DrinkingStatus": {
-            "properties": {
-              "value": {
-                "$ref": "#/components/schemas/SelfProfileResponse/$defs/DrinkingStatusProfile"
-              },
-              "visible": {
-                "type": "boolean"
-              }
-            },
-            "required": [
-              "value",
-              "visible"
-            ],
-            "type": "object"
-          },
-          "DrinkingStatusProfile": {
-            "enum": [
-              "PreferNotToSay",
-              "No",
-              "Yes",
-              "Sometimes"
-            ],
-            "type": "string"
-          },
-          "DrugStatus": {
-            "properties": {
-              "value": {
-                "$ref": "#/components/schemas/SelfProfileResponse/$defs/DrugStatusProfile"
-              },
-              "visible": {
-                "type": "boolean"
-              }
-            },
-            "required": [
-              "value",
-              "visible"
-            ],
-            "type": "object"
-          },
-          "DrugStatusProfile": {
-            "enum": [
-              "PreferNotToSay",
-              "No",
-              "Yes",
-              "Sometimes"
-            ],
-            "type": "string"
-          },
-          "EducationAttainedProfile": {
-            "enum": [
-              "PreferNotToSay",
-              "HighSchool",
-              "TradeSchool",
-              "InCollege",
-              "Undergraduate",
-              "InGradSchool",
-              "Graduate"
-            ],
-            "type": "string"
-          },
-          "Educations": {
-            "properties": {
-              "value": {
-                "items": {
-                  "type": "string"
-                },
-                "type": "array"
-              },
-              "visible": {
-                "type": "boolean"
-              }
-            },
-            "required": [
-              "value",
-              "visible"
-            ],
-            "type": "object"
-          },
-          "Ethnicities": {
-            "properties": {
-              "value": {
-                "items": {
-                  "$ref": "#/components/schemas/SelfProfileResponse/$defs/EthnicityProfile"
-                },
-                "type": "array"
-              },
-              "visible": {
-                "type": "boolean"
-              }
-            },
-            "required": [
-              "value",
-              "visible"
-            ],
-            "type": "object"
-          },
-          "EthnicityProfile": {
-            "enum": [
-              "PreferNotToSay",
-              "AmericanIndian",
-              "BlackAfrican",
-              "EastAsian",
-              "Hispanic",
-              "MiddleEastern",
-              "PacificIslander",
-              "SouthAsian",
-              "White",
-              "Other"
-            ],
-            "type": "string"
-          },
-          "FamilyPlans": {
-            "properties": {
-              "value": {
-                "format": "int32",
-                "type": "integer"
-              },
-              "visible": {
-                "type": "boolean"
-              }
-            },
-            "required": [
-              "value",
-              "visible"
-            ],
-            "type": "object"
-          },
-          "Feedback": {
-            "properties": {
-              "detail": {
-                "type": "string"
-              },
-              "evaluation": {
-                "type": "string"
-              },
-              "feedbackToken": {
-                "type": "string"
-              }
-            },
-            "required": [
-              "evaluation",
-              "detail",
-              "feedbackToken"
-            ],
-            "type": "object"
-          },
-          "GenderEnum": {
-            "enum": [
-              "Man",
-              "Woman",
-              "NonBinary"
-            ],
-            "type": "string"
-          },
-          "GenderIdentityId": {
-            "properties": {
-              "value": {
-                "format": "int32",
-                "type": "integer"
-              },
-              "visible": {
-                "type": "boolean"
-              }
-            },
-            "required": [
-              "value",
-              "visible"
-            ],
-            "type": "object"
-          },
-          "Hometown": {
-            "properties": {
-              "value": {
-                "type": "string"
-              },
-              "visible": {
-                "type": "boolean"
-              }
-            },
-            "required": [
-              "value",
-              "visible"
-            ],
-            "type": "object"
-          },
-          "JobTitle": {
-            "properties": {
-              "value": {
-                "type": "string"
-              },
-              "visible": {
-                "type": "boolean"
-              }
-            },
-            "required": [
-              "value",
-              "visible"
-            ],
-            "type": "object"
-          },
-          "LanguagesSpoken": {
-            "properties": {
-              "value": {
-                "items": {
-                  "format": "int32",
-                  "type": "integer"
-                },
-                "type": "array"
-              },
-              "visible": {
-                "type": "boolean"
-              }
-            },
-            "required": [
-              "value",
-              "visible"
-            ],
-            "type": "object"
-          },
-          "Location": {
-            "properties": {
-              "adminArea1Long": {
-                "type": [
-                  "string",
-                  "null"
-                ]
-              },
-              "adminArea1Short": {
-                "type": [
-                  "string",
-                  "null"
-                ]
-              },
-              "adminArea2": {
-                "type": [
-                  "string",
-                  "null"
-                ]
-              },
-              "countryShort": {
-                "type": [
-                  "string",
-                  "null"
-                ]
-              },
-              "latitude": {
-                "format": "double",
-                "type": [
-                  "number",
-                  "null"
-                ]
-              },
-              "longitude": {
-                "format": "double",
-                "type": [
-                  "number",
-                  "null"
-                ]
-              },
-              "metroArea": {
-                "type": [
-                  "string",
-                  "null"
-                ]
-              },
-              "metroAreaV2": {
-                "type": [
-                  "string",
-                  "null"
-                ]
-              },
-              "name": {
-                "type": "string"
-              }
-            },
-            "required": [
-              "name"
-            ],
-            "type": "object"
-          },
-          "MarijuanaStatus": {
-            "properties": {
-              "value": {
-                "$ref": "#/components/schemas/SelfProfileResponse/$defs/MarijuanaStatusProfile"
-              },
-              "visible": {
-                "type": "boolean"
-              }
-            },
-            "required": [
-              "value",
-              "visible"
-            ],
-            "type": "object"
-          },
-          "MarijuanaStatusProfile": {
-            "enum": [
-              "PreferNotToSay",
-              "No",
-              "Yes",
-              "Sometimes",
-              "NoPreference"
-            ],
-            "type": "string"
-          },
-          "PhotoAsset": {
-            "properties": {
-              "boundingBox": {
-                "anyOf": [
-                  {
-                    "$ref": "#/components/schemas/SelfProfileResponse/$defs/BoundingBox"
-                  },
-                  {
-                    "type": "null"
-                  }
-                ]
-              },
-              "caption": {
-                "type": [
-                  "string",
-                  "null"
-                ]
-              },
-              "cdnId": {
-                "type": [
-                  "string",
-                  "null"
-                ]
-              },
-              "contentId": {
-                "type": [
-                  "string",
-                  "null"
-                ]
-              },
-              "height": {
-                "format": "int32",
-                "type": [
-                  "integer",
-                  "null"
-                ]
-              },
-              "id": {
-                "type": [
-                  "string",
-                  "null"
-                ]
-              },
-              "location": {
-                "type": [
-                  "string",
-                  "null"
-                ]
-              },
-              "pHash": {
-                "type": [
-                  "string",
-                  "null"
-                ]
-              },
-              "promptId": {
-                "type": [
-                  "string",
-                  "null"
-                ]
-              },
-              "selfieVerified": {
-                "type": [
-                  "boolean",
-                  "null"
-                ]
-              },
-              "source": {
-                "type": [
-                  "string",
-                  "null"
-                ]
-              },
-              "sourceId": {
-                "type": [
-                  "string",
-                  "null"
-                ]
-              },
-              "url": {
-                "type": "string"
-              },
-              "videoUrl": {
-                "type": [
-                  "string",
-                  "null"
-                ]
-              },
-              "width": {
-                "format": "int32",
-                "type": [
-                  "integer",
-                  "null"
-                ]
-              }
-            },
-            "required": [
-              "url"
-            ],
-            "type": "object"
-          },
-          "Politics": {
-            "properties": {
-              "value": {
-                "$ref": "#/components/schemas/SelfProfileResponse/$defs/PoliticsProfile"
-              },
-              "visible": {
-                "type": "boolean"
-              }
-            },
-            "required": [
-              "value",
-              "visible"
-            ],
-            "type": "object"
-          },
-          "PoliticsProfile": {
-            "enum": [
-              "PreferNotToSay",
-              "Liberal",
-              "Moderate",
-              "Conservative",
-              "NotPolitical",
-              "Other"
-            ],
-            "type": "string"
-          },
-          "Profile": {
-            "properties": {
-              "age": {
-                "format": "int32",
-                "type": [
-                  "integer",
-                  "null"
-                ]
-              },
-              "answers": {
-                "default": [],
-                "items": {
-                  "$ref": "#/components/schemas/SelfProfileResponse/$defs/ProfileAnswer"
-                },
-                "type": "array"
-              },
-              "birthday": {
-                "type": [
-                  "string",
-                  "null"
-                ]
-              },
-              "children": {
-                "anyOf": [
-                  {
-                    "$ref": "#/components/schemas/SelfProfileResponse/$defs/ChildrenStatus"
-                  },
-                  {
-                    "type": "null"
-                  }
-                ]
-              },
-              "covidVax": {
-                "format": "int32",
-                "type": [
-                  "integer",
-                  "null"
-                ]
-              },
-              "datingIntention": {
-                "anyOf": [
-                  {
-                    "$ref": "#/components/schemas/SelfProfileResponse/$defs/DatingIntention"
-                  },
-                  {
-                    "type": "null"
-                  }
-                ]
-              },
-              "datingIntentionText": {
-                "type": [
-                  "string",
-                  "null"
-                ]
-              },
-              "didJustJoin": {
-                "type": [
-                  "boolean",
-                  "null"
-                ]
-              },
-              "drinking": {
-                "anyOf": [
-                  {
-                    "$ref": "#/components/schemas/SelfProfileResponse/$defs/DrinkingStatus"
-                  },
-                  {
-                    "type": "null"
-                  }
-                ]
-              },
-              "drugs": {
-                "anyOf": [
-                  {
-                    "$ref": "#/components/schemas/SelfProfileResponse/$defs/DrugStatus"
-                  },
-                  {
-                    "type": "null"
-                  }
-                ]
-              },
-              "educationAttained": {
-                "anyOf": [
-                  {
-                    "$ref": "#/components/schemas/SelfProfileResponse/$defs/EducationAttainedProfile"
-                  },
-                  {
-                    "type": "null"
-                  }
-                ]
-              },
-              "educations": {
-                "anyOf": [
-                  {
-                    "$ref": "#/components/schemas/SelfProfileResponse/$defs/Educations"
-                  },
-                  {
-                    "type": "null"
-                  }
-                ]
-              },
-              "email": {
-                "type": [
-                  "string",
-                  "null"
-                ]
-              },
-              "emailVerified": {
-                "type": [
-                  "boolean",
-                  "null"
-                ]
-              },
-              "ethnicities": {
-                "anyOf": [
-                  {
-                    "$ref": "#/components/schemas/SelfProfileResponse/$defs/Ethnicities"
-                  },
-                  {
-                    "type": "null"
-                  }
-                ]
-              },
-              "ethnicitiesText": {
-                "type": [
-                  "string",
-                  "null"
-                ]
-              },
-              "familyPlans": {
-                "anyOf": [
-                  {
-                    "$ref": "#/components/schemas/SelfProfileResponse/$defs/FamilyPlans"
-                  },
-                  {
-                    "type": "null"
-                  }
-                ]
-              },
-              "firstCompletedDate": {
-                "type": [
-                  "string",
-                  "null"
-                ]
-              },
-              "firstName": {
-                "type": "string"
-              },
-              "genderId": {
-                "anyOf": [
-                  {
-                    "$ref": "#/components/schemas/SelfProfileResponse/$defs/GenderEnum"
-                  },
-                  {
-                    "type": "null"
-                  }
-                ]
-              },
-              "genderIdentity": {
-                "type": [
-                  "string",
-                  "null"
-                ]
-              },
-              "genderIdentityId": {
-                "anyOf": [
-                  {
-                    "$ref": "#/components/schemas/SelfProfileResponse/$defs/GenderIdentityId"
-                  },
-                  {
-                    "type": "null"
-                  }
-                ]
-              },
-              "height": {
-                "format": "int32",
-                "type": [
-                  "integer",
-                  "null"
-                ]
-              },
-              "hometown": {
-                "anyOf": [
-                  {
-                    "$ref": "#/components/schemas/SelfProfileResponse/$defs/Hometown"
-                  },
-                  {
-                    "type": "null"
-                  }
-                ]
-              },
-              "jobTitle": {
-                "anyOf": [
-                  {
-                    "$ref": "#/components/schemas/SelfProfileResponse/$defs/JobTitle"
-                  },
-                  {
-                    "type": "null"
-                  }
-                ]
-              },
-              "languagesSpoken": {
-                "anyOf": [
-                  {
-                    "$ref": "#/components/schemas/SelfProfileResponse/$defs/LanguagesSpoken"
-                  },
-                  {
-                    "type": "null"
-                  }
-                ]
-              },
-              "lastActiveStatusId": {
-                "format": "int32",
-                "type": [
-                  "integer",
-                  "null"
-                ]
-              },
-              "lastName": {
-                "type": [
-                  "string",
-                  "null"
-                ]
-              },
-              "location": {
-                "$ref": "#/components/schemas/SelfProfileResponse/$defs/Location"
-              },
-              "marijuana": {
-                "anyOf": [
-                  {
-                    "$ref": "#/components/schemas/SelfProfileResponse/$defs/MarijuanaStatus"
-                  },
-                  {
-                    "type": "null"
-                  }
-                ]
-              },
-              "name": {
-                "anyOf": [
-                  {
-                    "$ref": "#/components/schemas/SelfProfileResponse/$defs/ProfileName"
-                  },
-                  {
-                    "type": "null"
-                  }
-                ]
-              },
-              "pets": true,
-              "phone": {
-                "type": [
-                  "string",
-                  "null"
-                ]
-              },
-              "photos": {
-                "default": [],
-                "items": {
-                  "$ref": "#/components/schemas/SelfProfileResponse/$defs/PhotoAsset"
-                },
-                "type": "array"
-              },
-              "politics": {
-                "anyOf": [
-                  {
-                    "$ref": "#/components/schemas/SelfProfileResponse/$defs/Politics"
-                  },
-                  {
-                    "type": "null"
-                  }
-                ]
-              },
-              "pronouns": {
-                "anyOf": [
-                  {
-                    "$ref": "#/components/schemas/SelfProfileResponse/$defs/Pronouns"
-                  },
-                  {
-                    "type": "null"
-                  }
-                ]
-              },
-              "relationshipTypeIds": {
-                "anyOf": [
-                  {
-                    "$ref": "#/components/schemas/SelfProfileResponse/$defs/RelationshipTypeIds"
-                  },
-                  {
-                    "type": "null"
-                  }
-                ]
-              },
-              "relationshipTypesText": {
-                "type": [
-                  "string",
-                  "null"
-                ]
-              },
-              "religions": {
-                "anyOf": [
-                  {
-                    "$ref": "#/components/schemas/SelfProfileResponse/$defs/Religion"
-                  },
-                  {
-                    "type": "null"
-                  }
-                ]
-              },
-              "selfieVerified": {
-                "type": [
-                  "boolean",
-                  "null"
-                ]
-              },
-              "sexualOrientations": {
-                "anyOf": [
-                  {
-                    "$ref": "#/components/schemas/SelfProfileResponse/$defs/SexualOrientations"
-                  },
-                  {
-                    "type": "null"
-                  }
-                ]
-              },
-              "smoking": {
-                "anyOf": [
-                  {
-                    "$ref": "#/components/schemas/SelfProfileResponse/$defs/SmokingStatus"
-                  },
-                  {
-                    "type": "null"
-                  }
-                ]
-              },
-              "works": {
-                "anyOf": [
-                  {
-                    "$ref": "#/components/schemas/SelfProfileResponse/$defs/Works"
-                  },
-                  {
-                    "type": "null"
-                  }
-                ]
-              },
-              "zodiac": {
-                "anyOf": [
-                  {
-                    "$ref": "#/components/schemas/SelfProfileResponse/$defs/Zodiac"
-                  },
-                  {
-                    "type": "null"
-                  }
-                ]
-              }
-            },
-            "required": [
-              "firstName",
-              "location"
-            ],
-            "type": "object"
-          },
-          "ProfileAnswer": {
-            "properties": {
-              "cdnId": {
-                "type": [
-                  "string",
-                  "null"
-                ]
-              },
-              "content": {
-                "type": [
-                  "string",
-                  "null"
-                ]
-              },
-              "contentId": {
-                "type": [
-                  "string",
-                  "null"
-                ]
-              },
-              "feedback": {
-                "anyOf": [
-                  {
-                    "$ref": "#/components/schemas/SelfProfileResponse/$defs/Feedback"
-                  },
-                  {
-                    "type": "null"
-                  }
-                ]
-              },
-              "position": {
-                "format": "int32",
-                "type": [
-                  "integer",
-                  "null"
-                ]
-              },
-              "promptId": {
-                "type": [
-                  "string",
-                  "null"
-                ]
-              },
-              "questionId": {
-                "type": [
-                  "string",
-                  "null"
-                ]
-              },
-              "response": {
-                "type": [
-                  "string",
-                  "null"
-                ]
-              },
-              "transcription": {
-                "type": [
-                  "string",
-                  "null"
-                ]
-              },
-              "transcriptionMetadata": true,
-              "type": {
-                "type": [
-                  "string",
-                  "null"
-                ]
-              },
-              "url": {
-                "type": [
-                  "string",
-                  "null"
-                ]
-              },
-              "waveform": {
-                "type": [
-                  "string",
-                  "null"
-                ]
-              }
-            },
-            "type": "object"
-          },
-          "ProfileName": {
-            "properties": {
-              "firstName": {
-                "type": "string"
-              },
-              "lastName": {
-                "default": null,
-                "type": [
-                  "string",
-                  "null"
-                ]
-              }
-            },
-            "required": [
-              "firstName"
-            ],
-            "type": "object"
-          },
-          "Pronouns": {
-            "properties": {
-              "value": {
-                "items": {
-                  "format": "int32",
-                  "type": "integer"
-                },
-                "type": "array"
-              },
-              "visible": {
-                "type": "boolean"
-              }
-            },
-            "required": [
-              "value",
-              "visible"
-            ],
-            "type": "object"
-          },
-          "RelationshipTypeIds": {
-            "properties": {
-              "value": {
-                "items": {
-                  "$ref": "#/components/schemas/SelfProfileResponse/$defs/RelationshipTypeProfile"
-                },
-                "type": "array"
-              },
-              "visible": {
-                "type": "boolean"
-              }
-            },
-            "required": [
-              "value",
-              "visible"
-            ],
-            "type": "object"
-          },
-          "RelationshipTypeProfile": {
-            "enum": [
-              "PreferNotToSay",
-              "Monogamy",
-              "EthicalNonMonogamy",
-              "FiguringOutTheirRelationshipType"
-            ],
-            "type": "string"
-          },
-          "Religion": {
-            "properties": {
-              "value": {
-                "items": {
-                  "$ref": "#/components/schemas/SelfProfileResponse/$defs/ReligionProfile"
-                },
-                "type": "array"
-              },
-              "visible": {
-                "type": "boolean"
-              }
-            },
-            "required": [
-              "value",
-              "visible"
-            ],
-            "type": "object"
-          },
-          "ReligionProfile": {
-            "enum": [
-              "PreferNotToSay",
-              "Spiritual",
-              "Catholic",
-              "Christian",
-              "Hindu",
-              "Jewish",
-              "Muslim",
-              "Buddhist",
-              "Agnostic",
-              "Atheist",
-              "Other",
-              "Sikh"
-            ],
-            "type": "string"
-          },
-          "SexualOrientations": {
-            "properties": {
-              "value": {
-                "items": {
-                  "format": "int32",
-                  "type": "integer"
-                },
-                "type": "array"
-              },
-              "visible": {
-                "type": "boolean"
-              }
-            },
-            "required": [
-              "value",
-              "visible"
-            ],
-            "type": "object"
-          },
-          "SmokingStatus": {
-            "properties": {
-              "value": {
-                "$ref": "#/components/schemas/SelfProfileResponse/$defs/SmokingStatusProfile"
-              },
-              "visible": {
-                "type": "boolean"
-              }
-            },
-            "required": [
-              "value",
-              "visible"
-            ],
-            "type": "object"
-          },
-          "SmokingStatusProfile": {
-            "enum": [
-              "PreferNotToSay",
-              "No",
-              "Yes",
-              "Sometimes"
-            ],
-            "type": "string"
-          },
-          "Works": {
-            "properties": {
-              "value": {
-                "type": "string"
-              },
-              "visible": {
-                "type": "boolean"
-              }
-            },
-            "required": [
-              "value",
-              "visible"
-            ],
-            "type": "object"
-          },
-          "Zodiac": {
-            "properties": {
-              "value": {
-                "format": "int32",
-                "type": "integer"
-              },
-              "visible": {
-                "type": "boolean"
-              }
-            },
-            "required": [
-              "value",
-              "visible"
-            ],
-            "type": "object"
-          }
-        },
         "properties": {
           "created": {
             "type": "string"
@@ -11497,7 +3906,7 @@
             "type": "boolean"
           },
           "profile": {
-            "$ref": "#/components/schemas/SelfProfileResponse/$defs/Profile"
+            "$ref": "#/components/schemas/Profile"
           },
           "registered": {
             "type": "string"
@@ -11519,19 +3928,6 @@
         "type": "object"
       },
       "SendMessagePayload": {
-        "$defs": {
-          "MessageData": {
-            "properties": {
-              "message": {
-                "type": "string"
-              }
-            },
-            "required": [
-              "message"
-            ],
-            "type": "object"
-          }
-        },
         "properties": {
           "ays": {
             "type": "boolean"
@@ -11546,7 +3942,7 @@
             "type": "boolean"
           },
           "messageData": {
-            "$ref": "#/components/schemas/SendMessagePayload/$defs/MessageData"
+            "$ref": "#/components/schemas/MessageData"
           },
           "messageType": {
             "type": "string"
@@ -11647,261 +4043,11 @@
         "type": "object"
       },
       "SendbirdChannelsResponse": {
-        "$defs": {
-          "SendbirdChannelMember": {
-            "properties": {
-              "is_active": {
-                "default": false,
-                "type": "boolean"
-              },
-              "metadata": {
-                "default": null
-              },
-              "nickname": {
-                "default": "",
-                "type": "string"
-              },
-              "profile_url": {
-                "default": "",
-                "type": "string"
-              },
-              "user_id": {
-                "default": "",
-                "type": "string"
-              }
-            },
-            "type": "object"
-          },
-          "SendbirdGroupChannel": {
-            "properties": {
-              "channel_url": {
-                "type": "string"
-              },
-              "cover_url": {
-                "default": "",
-                "type": "string"
-              },
-              "created_at": {
-                "default": "",
-                "type": "string"
-              },
-              "custom_type": {
-                "default": "",
-                "type": "string"
-              },
-              "joined_member_count": {
-                "default": 0,
-                "format": "int32",
-                "type": "integer"
-              },
-              "last_message": {
-                "anyOf": [
-                  {
-                    "$ref": "#/components/schemas/SendbirdChannelsResponse/$defs/SendbirdMessage"
-                  },
-                  {
-                    "type": "null"
-                  }
-                ],
-                "default": null
-              },
-              "member_count": {
-                "default": 0,
-                "format": "int32",
-                "type": "integer"
-              },
-              "members": {
-                "default": [],
-                "items": {
-                  "$ref": "#/components/schemas/SendbirdChannelsResponse/$defs/SendbirdChannelMember"
-                },
-                "type": "array"
-              },
-              "metadata": {
-                "default": null
-              },
-              "my_member_state": {
-                "default": "",
-                "type": "string"
-              },
-              "name": {
-                "default": "",
-                "type": "string"
-              },
-              "unread_message_count": {
-                "default": 0,
-                "format": "int32",
-                "type": "integer"
-              },
-              "updated_at": {
-                "default": "",
-                "type": "string"
-              }
-            },
-            "required": [
-              "channel_url"
-            ],
-            "type": "object"
-          },
-          "SendbirdMessage": {
-            "properties": {
-              "channel_type": {
-                "default": "",
-                "type": "string"
-              },
-              "channel_url": {
-                "type": "string"
-              },
-              "created_at": {
-                "type": "string"
-              },
-              "custom_type": {
-                "default": "",
-                "type": "string"
-              },
-              "data": {
-                "default": "",
-                "type": "string"
-              },
-              "file": {
-                "default": null
-              },
-              "is_op_msg": {
-                "default": false,
-                "type": "boolean"
-              },
-              "is_removed": {
-                "default": false,
-                "type": "boolean"
-              },
-              "mention_type": {
-                "default": "",
-                "type": "string"
-              },
-              "mentioned_users": {
-                "default": [],
-                "items": true,
-                "type": "array"
-              },
-              "message": {
-                "default": "",
-                "type": "string"
-              },
-              "message_events": {
-                "default": null
-              },
-              "message_id": {
-                "type": "string"
-              },
-              "message_retention_hour": {
-                "default": "",
-                "type": "string"
-              },
-              "message_survival_seconds": {
-                "default": "",
-                "type": "string"
-              },
-              "reactions_summary": {
-                "default": [],
-                "items": true,
-                "type": "array"
-              },
-              "silent": {
-                "default": false,
-                "type": "boolean"
-              },
-              "sorted_metaarray": {
-                "default": [],
-                "items": {
-                  "$ref": "#/components/schemas/SendbirdChannelsResponse/$defs/SendbirdMessageMetaItem"
-                },
-                "type": "array"
-              },
-              "translations": {
-                "default": null
-              },
-              "type": {
-                "type": "string"
-              },
-              "updated_at": {
-                "default": "",
-                "type": "string"
-              },
-              "user": {
-                "$ref": "#/components/schemas/SendbirdChannelsResponse/$defs/SendbirdMessageUser"
-              }
-            },
-            "required": [
-              "type",
-              "message_id",
-              "created_at",
-              "user",
-              "channel_url"
-            ],
-            "type": "object"
-          },
-          "SendbirdMessageMetaItem": {
-            "properties": {
-              "key": {
-                "type": "string"
-              },
-              "value": {
-                "items": {
-                  "type": "string"
-                },
-                "type": "array"
-              }
-            },
-            "required": [
-              "key",
-              "value"
-            ],
-            "type": "object"
-          },
-          "SendbirdMessageUser": {
-            "properties": {
-              "is_active": {
-                "default": false,
-                "type": "boolean"
-              },
-              "is_blocked_by_me": {
-                "default": false,
-                "type": "boolean"
-              },
-              "metadata": {
-                "default": null
-              },
-              "nickname": {
-                "default": "",
-                "type": "string"
-              },
-              "profile_url": {
-                "default": "",
-                "type": "string"
-              },
-              "require_auth_for_profile_image": {
-                "default": false,
-                "type": "boolean"
-              },
-              "role": {
-                "default": "",
-                "type": "string"
-              },
-              "user_id": {
-                "type": "string"
-              }
-            },
-            "required": [
-              "user_id"
-            ],
-            "type": "object"
-          }
-        },
         "properties": {
           "channels": {
             "default": [],
             "items": {
-              "$ref": "#/components/schemas/SendbirdChannelsResponse/$defs/SendbirdGroupChannel"
+              "$ref": "#/components/schemas/SendbirdGroupChannel"
             },
             "type": "array"
           }
@@ -11959,185 +4105,6 @@
         "type": "object"
       },
       "SendbirdGroupChannel": {
-        "$defs": {
-          "SendbirdChannelMember": {
-            "properties": {
-              "is_active": {
-                "default": false,
-                "type": "boolean"
-              },
-              "metadata": {
-                "default": null
-              },
-              "nickname": {
-                "default": "",
-                "type": "string"
-              },
-              "profile_url": {
-                "default": "",
-                "type": "string"
-              },
-              "user_id": {
-                "default": "",
-                "type": "string"
-              }
-            },
-            "type": "object"
-          },
-          "SendbirdMessage": {
-            "properties": {
-              "channel_type": {
-                "default": "",
-                "type": "string"
-              },
-              "channel_url": {
-                "type": "string"
-              },
-              "created_at": {
-                "type": "string"
-              },
-              "custom_type": {
-                "default": "",
-                "type": "string"
-              },
-              "data": {
-                "default": "",
-                "type": "string"
-              },
-              "file": {
-                "default": null
-              },
-              "is_op_msg": {
-                "default": false,
-                "type": "boolean"
-              },
-              "is_removed": {
-                "default": false,
-                "type": "boolean"
-              },
-              "mention_type": {
-                "default": "",
-                "type": "string"
-              },
-              "mentioned_users": {
-                "default": [],
-                "items": true,
-                "type": "array"
-              },
-              "message": {
-                "default": "",
-                "type": "string"
-              },
-              "message_events": {
-                "default": null
-              },
-              "message_id": {
-                "type": "string"
-              },
-              "message_retention_hour": {
-                "default": "",
-                "type": "string"
-              },
-              "message_survival_seconds": {
-                "default": "",
-                "type": "string"
-              },
-              "reactions_summary": {
-                "default": [],
-                "items": true,
-                "type": "array"
-              },
-              "silent": {
-                "default": false,
-                "type": "boolean"
-              },
-              "sorted_metaarray": {
-                "default": [],
-                "items": {
-                  "$ref": "#/components/schemas/SendbirdGroupChannel/$defs/SendbirdMessageMetaItem"
-                },
-                "type": "array"
-              },
-              "translations": {
-                "default": null
-              },
-              "type": {
-                "type": "string"
-              },
-              "updated_at": {
-                "default": "",
-                "type": "string"
-              },
-              "user": {
-                "$ref": "#/components/schemas/SendbirdGroupChannel/$defs/SendbirdMessageUser"
-              }
-            },
-            "required": [
-              "type",
-              "message_id",
-              "created_at",
-              "user",
-              "channel_url"
-            ],
-            "type": "object"
-          },
-          "SendbirdMessageMetaItem": {
-            "properties": {
-              "key": {
-                "type": "string"
-              },
-              "value": {
-                "items": {
-                  "type": "string"
-                },
-                "type": "array"
-              }
-            },
-            "required": [
-              "key",
-              "value"
-            ],
-            "type": "object"
-          },
-          "SendbirdMessageUser": {
-            "properties": {
-              "is_active": {
-                "default": false,
-                "type": "boolean"
-              },
-              "is_blocked_by_me": {
-                "default": false,
-                "type": "boolean"
-              },
-              "metadata": {
-                "default": null
-              },
-              "nickname": {
-                "default": "",
-                "type": "string"
-              },
-              "profile_url": {
-                "default": "",
-                "type": "string"
-              },
-              "require_auth_for_profile_image": {
-                "default": false,
-                "type": "boolean"
-              },
-              "role": {
-                "default": "",
-                "type": "string"
-              },
-              "user_id": {
-                "type": "string"
-              }
-            },
-            "required": [
-              "user_id"
-            ],
-            "type": "object"
-          }
-        },
         "properties": {
           "channel_url": {
             "type": "string"
@@ -12162,7 +4129,7 @@
           "last_message": {
             "anyOf": [
               {
-                "$ref": "#/components/schemas/SendbirdGroupChannel/$defs/SendbirdMessage"
+                "$ref": "#/components/schemas/SendbirdMessage"
               },
               {
                 "type": "null"
@@ -12178,7 +4145,7 @@
           "members": {
             "default": [],
             "items": {
-              "$ref": "#/components/schemas/SendbirdGroupChannel/$defs/SendbirdChannelMember"
+              "$ref": "#/components/schemas/SendbirdChannelMember"
             },
             "type": "array"
           },
@@ -12210,64 +4177,6 @@
         "type": "object"
       },
       "SendbirdMessage": {
-        "$defs": {
-          "SendbirdMessageMetaItem": {
-            "properties": {
-              "key": {
-                "type": "string"
-              },
-              "value": {
-                "items": {
-                  "type": "string"
-                },
-                "type": "array"
-              }
-            },
-            "required": [
-              "key",
-              "value"
-            ],
-            "type": "object"
-          },
-          "SendbirdMessageUser": {
-            "properties": {
-              "is_active": {
-                "default": false,
-                "type": "boolean"
-              },
-              "is_blocked_by_me": {
-                "default": false,
-                "type": "boolean"
-              },
-              "metadata": {
-                "default": null
-              },
-              "nickname": {
-                "default": "",
-                "type": "string"
-              },
-              "profile_url": {
-                "default": "",
-                "type": "string"
-              },
-              "require_auth_for_profile_image": {
-                "default": false,
-                "type": "boolean"
-              },
-              "role": {
-                "default": "",
-                "type": "string"
-              },
-              "user_id": {
-                "type": "string"
-              }
-            },
-            "required": [
-              "user_id"
-            ],
-            "type": "object"
-          }
-        },
         "properties": {
           "channel_type": {
             "default": "",
@@ -12337,7 +4246,7 @@
           "sorted_metaarray": {
             "default": [],
             "items": {
-              "$ref": "#/components/schemas/SendbirdMessage/$defs/SendbirdMessageMetaItem"
+              "$ref": "#/components/schemas/SendbirdMessageMetaItem"
             },
             "type": "array"
           },
@@ -12352,7 +4261,7 @@
             "type": "string"
           },
           "user": {
-            "$ref": "#/components/schemas/SendbirdMessage/$defs/SendbirdMessageUser"
+            "$ref": "#/components/schemas/SendbirdMessageUser"
           }
         },
         "required": [
@@ -12424,165 +4333,10 @@
         "type": "object"
       },
       "SendbirdMessagesResponse": {
-        "$defs": {
-          "SendbirdMessage": {
-            "properties": {
-              "channel_type": {
-                "default": "",
-                "type": "string"
-              },
-              "channel_url": {
-                "type": "string"
-              },
-              "created_at": {
-                "type": "string"
-              },
-              "custom_type": {
-                "default": "",
-                "type": "string"
-              },
-              "data": {
-                "default": "",
-                "type": "string"
-              },
-              "file": {
-                "default": null
-              },
-              "is_op_msg": {
-                "default": false,
-                "type": "boolean"
-              },
-              "is_removed": {
-                "default": false,
-                "type": "boolean"
-              },
-              "mention_type": {
-                "default": "",
-                "type": "string"
-              },
-              "mentioned_users": {
-                "default": [],
-                "items": true,
-                "type": "array"
-              },
-              "message": {
-                "default": "",
-                "type": "string"
-              },
-              "message_events": {
-                "default": null
-              },
-              "message_id": {
-                "type": "string"
-              },
-              "message_retention_hour": {
-                "default": "",
-                "type": "string"
-              },
-              "message_survival_seconds": {
-                "default": "",
-                "type": "string"
-              },
-              "reactions_summary": {
-                "default": [],
-                "items": true,
-                "type": "array"
-              },
-              "silent": {
-                "default": false,
-                "type": "boolean"
-              },
-              "sorted_metaarray": {
-                "default": [],
-                "items": {
-                  "$ref": "#/components/schemas/SendbirdMessagesResponse/$defs/SendbirdMessageMetaItem"
-                },
-                "type": "array"
-              },
-              "translations": {
-                "default": null
-              },
-              "type": {
-                "type": "string"
-              },
-              "updated_at": {
-                "default": "",
-                "type": "string"
-              },
-              "user": {
-                "$ref": "#/components/schemas/SendbirdMessagesResponse/$defs/SendbirdMessageUser"
-              }
-            },
-            "required": [
-              "type",
-              "message_id",
-              "created_at",
-              "user",
-              "channel_url"
-            ],
-            "type": "object"
-          },
-          "SendbirdMessageMetaItem": {
-            "properties": {
-              "key": {
-                "type": "string"
-              },
-              "value": {
-                "items": {
-                  "type": "string"
-                },
-                "type": "array"
-              }
-            },
-            "required": [
-              "key",
-              "value"
-            ],
-            "type": "object"
-          },
-          "SendbirdMessageUser": {
-            "properties": {
-              "is_active": {
-                "default": false,
-                "type": "boolean"
-              },
-              "is_blocked_by_me": {
-                "default": false,
-                "type": "boolean"
-              },
-              "metadata": {
-                "default": null
-              },
-              "nickname": {
-                "default": "",
-                "type": "string"
-              },
-              "profile_url": {
-                "default": "",
-                "type": "string"
-              },
-              "require_auth_for_profile_image": {
-                "default": false,
-                "type": "boolean"
-              },
-              "role": {
-                "default": "",
-                "type": "string"
-              },
-              "user_id": {
-                "type": "string"
-              }
-            },
-            "required": [
-              "user_id"
-            ],
-            "type": "object"
-          }
-        },
         "properties": {
           "messages": {
             "items": {
-              "$ref": "#/components/schemas/SendbirdMessagesResponse/$defs/SendbirdMessage"
+              "$ref": "#/components/schemas/SendbirdMessage"
             },
             "type": "array"
           }
@@ -12594,54 +4348,6 @@
         "type": "object"
       },
       "SendbirdReadResponse": {
-        "$defs": {
-          "SendbirdReadUser": {
-            "properties": {
-              "guest_id": {
-                "type": "string"
-              },
-              "id": {
-                "type": "string"
-              },
-              "image": {
-                "type": "string"
-              },
-              "is_active": {
-                "type": "boolean"
-              },
-              "is_ai_bot": {
-                "type": "boolean"
-              },
-              "is_bot": {
-                "type": "boolean"
-              },
-              "metadata": {
-                "default": null
-              },
-              "name": {
-                "type": "string"
-              },
-              "require_auth_for_profile_image": {
-                "type": "boolean"
-              },
-              "role": {
-                "type": "string"
-              }
-            },
-            "required": [
-              "name",
-              "image",
-              "require_auth_for_profile_image",
-              "guest_id",
-              "id",
-              "role",
-              "is_bot",
-              "is_ai_bot",
-              "is_active"
-            ],
-            "type": "object"
-          }
-        },
         "properties": {
           "channel_id": {
             "type": "string"
@@ -12671,7 +4377,7 @@
             "type": "string"
           },
           "user": {
-            "$ref": "#/components/schemas/SendbirdReadResponse/$defs/SendbirdReadUser"
+            "$ref": "#/components/schemas/SendbirdReadUser"
           }
         },
         "required": [
@@ -12735,34 +4441,6 @@
         "type": "object"
       },
       "SendbirdSyevEvent": {
-        "$defs": {
-          "SendbirdSyevUserData": {
-            "properties": {
-              "metadata": {
-                "default": null
-              },
-              "nickname": {
-                "default": "",
-                "type": "string"
-              },
-              "profile_url": {
-                "default": "",
-                "type": "string"
-              },
-              "require_auth_for_profile_image": {
-                "default": false,
-                "type": "boolean"
-              },
-              "user_id": {
-                "type": "string"
-              }
-            },
-            "required": [
-              "user_id"
-            ],
-            "type": "object"
-          }
-        },
         "properties": {
           "cat": {
             "format": "int32",
@@ -12784,7 +4462,7 @@
           "data": {
             "anyOf": [
               {
-                "$ref": "#/components/schemas/SendbirdSyevEvent/$defs/SendbirdSyevUserData"
+                "$ref": "#/components/schemas/SendbirdSyevUserData"
               },
               {
                 "type": "null"
@@ -12853,96 +4531,6 @@
         "type": "object"
       },
       "SendbirdWsEvent": {
-        "$defs": {
-          "SendbirdSyevEvent": {
-            "properties": {
-              "cat": {
-                "format": "int32",
-                "type": "integer"
-              },
-              "channel_id": {
-                "default": null,
-                "type": [
-                  "string",
-                  "null"
-                ]
-              },
-              "channel_type": {
-                "type": "string"
-              },
-              "channel_url": {
-                "type": "string"
-              },
-              "data": {
-                "anyOf": [
-                  {
-                    "$ref": "#/components/schemas/SendbirdWsEvent/$defs/SendbirdSyevUserData"
-                  },
-                  {
-                    "type": "null"
-                  }
-                ],
-                "default": null
-              },
-              "has_ai_bot": {
-                "default": false,
-                "type": "boolean"
-              },
-              "has_bot": {
-                "default": false,
-                "type": "boolean"
-              },
-              "is_access_code_required": {
-                "default": false,
-                "type": "boolean"
-              },
-              "is_super": {
-                "default": false,
-                "type": "boolean"
-              },
-              "sts": {
-                "default": "",
-                "type": "string"
-              },
-              "ts": {
-                "default": "",
-                "type": "string"
-              }
-            },
-            "required": [
-              "cat",
-              "channel_url",
-              "channel_type"
-            ],
-            "type": "object"
-          },
-          "SendbirdSyevUserData": {
-            "properties": {
-              "metadata": {
-                "default": null
-              },
-              "nickname": {
-                "default": "",
-                "type": "string"
-              },
-              "profile_url": {
-                "default": "",
-                "type": "string"
-              },
-              "require_auth_for_profile_image": {
-                "default": false,
-                "type": "boolean"
-              },
-              "user_id": {
-                "type": "string"
-              }
-            },
-            "required": [
-              "user_id"
-            ],
-            "type": "object"
-          }
-        },
         "oneOf": [
           {
             "properties": {
@@ -12984,7 +4572,7 @@
           {
             "properties": {
               "event": {
-                "$ref": "#/components/schemas/SendbirdWsEvent/$defs/SendbirdSyevEvent"
+                "$ref": "#/components/schemas/SendbirdSyevEvent"
               },
               "kind": {
                 "const": "typing",
@@ -13071,6 +4659,25 @@
         ],
         "title": "SendbirdWsEvent"
       },
+      "SexualOrientations": {
+        "properties": {
+          "value": {
+            "items": {
+              "format": "int32",
+              "type": "integer"
+            },
+            "type": "array"
+          },
+          "visible": {
+            "type": "boolean"
+          }
+        },
+        "required": [
+          "value",
+          "visible"
+        ],
+        "type": "object"
+      },
       "SkipInput": {
         "properties": {
           "origin": {
@@ -13093,6 +4700,39 @@
         ],
         "title": "SkipInput",
         "type": "object"
+      },
+      "SmokingStatus": {
+        "properties": {
+          "value": {
+            "$ref": "#/components/schemas/SmokingStatusProfile"
+          },
+          "visible": {
+            "type": "boolean"
+          }
+        },
+        "required": [
+          "value",
+          "visible"
+        ],
+        "type": "object"
+      },
+      "SmokingStatusPreference": {
+        "enum": [
+          "OpenToAll",
+          "No",
+          "Yes",
+          "Sometimes"
+        ],
+        "type": "string"
+      },
+      "SmokingStatusProfile": {
+        "enum": [
+          "PreferNotToSay",
+          "No",
+          "Yes",
+          "Sometimes"
+        ],
+        "type": "string"
       },
       "SmsInitiateRequest": {
         "additionalProperties": true,
@@ -13119,23 +4759,10 @@
         "type": "object"
       },
       "SortedLikesGroupV2": {
-        "$defs": {
-          "SortedLikeIdV2": {
-            "properties": {
-              "id": {
-                "type": "string"
-              }
-            },
-            "required": [
-              "id"
-            ],
-            "type": "object"
-          }
-        },
         "properties": {
           "data": {
             "items": {
-              "$ref": "#/components/schemas/SortedLikesGroupV2/$defs/SortedLikeIdV2"
+              "$ref": "#/components/schemas/SortedLikeIdV2"
             },
             "type": "array"
           },
@@ -13151,24 +4778,11 @@
         "type": "object"
       },
       "StandoutContent": {
-        "$defs": {
-          "StandoutMediaRef": {
-            "properties": {
-              "contentId": {
-                "type": "string"
-              }
-            },
-            "required": [
-              "contentId"
-            ],
-            "type": "object"
-          }
-        },
         "properties": {
           "photo": {
             "anyOf": [
               {
-                "$ref": "#/components/schemas/StandoutContent/$defs/StandoutMediaRef"
+                "$ref": "#/components/schemas/StandoutMediaRef"
               },
               {
                 "type": "null"
@@ -13179,7 +4793,7 @@
           "prompt": {
             "anyOf": [
               {
-                "$ref": "#/components/schemas/StandoutContent/$defs/StandoutMediaRef"
+                "$ref": "#/components/schemas/StandoutMediaRef"
               },
               {
                 "type": "null"
@@ -13192,49 +4806,9 @@
         "type": "object"
       },
       "StandoutItem": {
-        "$defs": {
-          "StandoutContent": {
-            "properties": {
-              "photo": {
-                "anyOf": [
-                  {
-                    "$ref": "#/components/schemas/StandoutItem/$defs/StandoutMediaRef"
-                  },
-                  {
-                    "type": "null"
-                  }
-                ],
-                "default": null
-              },
-              "prompt": {
-                "anyOf": [
-                  {
-                    "$ref": "#/components/schemas/StandoutItem/$defs/StandoutMediaRef"
-                  },
-                  {
-                    "type": "null"
-                  }
-                ],
-                "default": null
-              }
-            },
-            "type": "object"
-          },
-          "StandoutMediaRef": {
-            "properties": {
-              "contentId": {
-                "type": "string"
-              }
-            },
-            "required": [
-              "contentId"
-            ],
-            "type": "object"
-          }
-        },
         "properties": {
           "content": {
-            "$ref": "#/components/schemas/StandoutItem/$defs/StandoutContent"
+            "$ref": "#/components/schemas/StandoutContent"
           },
           "ratingToken": {
             "type": "string"
@@ -13264,65 +4838,6 @@
         "type": "object"
       },
       "StandoutsResponse": {
-        "$defs": {
-          "StandoutContent": {
-            "properties": {
-              "photo": {
-                "anyOf": [
-                  {
-                    "$ref": "#/components/schemas/StandoutsResponse/$defs/StandoutMediaRef"
-                  },
-                  {
-                    "type": "null"
-                  }
-                ],
-                "default": null
-              },
-              "prompt": {
-                "anyOf": [
-                  {
-                    "$ref": "#/components/schemas/StandoutsResponse/$defs/StandoutMediaRef"
-                  },
-                  {
-                    "type": "null"
-                  }
-                ],
-                "default": null
-              }
-            },
-            "type": "object"
-          },
-          "StandoutItem": {
-            "properties": {
-              "content": {
-                "$ref": "#/components/schemas/StandoutsResponse/$defs/StandoutContent"
-              },
-              "ratingToken": {
-                "type": "string"
-              },
-              "subjectId": {
-                "type": "string"
-              }
-            },
-            "required": [
-              "subjectId",
-              "ratingToken",
-              "content"
-            ],
-            "type": "object"
-          },
-          "StandoutMediaRef": {
-            "properties": {
-              "contentId": {
-                "type": "string"
-              }
-            },
-            "required": [
-              "contentId"
-            ],
-            "type": "object"
-          }
-        },
         "properties": {
           "expiration": {
             "default": null,
@@ -13334,7 +4849,7 @@
           "standouts": {
             "default": [],
             "items": {
-              "$ref": "#/components/schemas/StandoutsResponse/$defs/StandoutItem"
+              "$ref": "#/components/schemas/StandoutItem"
             },
             "type": "array"
           },
@@ -13418,45 +4933,9 @@
         "type": "array"
       },
       "VideoPrompt": {
-        "$defs": {
-          "BoundingBox": {
-            "properties": {
-              "bottomRight": {
-                "$ref": "#/components/schemas/VideoPrompt/$defs/Coordinate",
-                "default": {
-                  "x": 0.0,
-                  "y": 0.0
-                }
-              },
-              "topLeft": {
-                "$ref": "#/components/schemas/VideoPrompt/$defs/Coordinate",
-                "default": {
-                  "x": 0.0,
-                  "y": 0.0
-                }
-              }
-            },
-            "type": "object"
-          },
-          "Coordinate": {
-            "properties": {
-              "x": {
-                "default": 0.0,
-                "format": "double",
-                "type": "number"
-              },
-              "y": {
-                "default": 0.0,
-                "format": "double",
-                "type": "number"
-              }
-            },
-            "type": "object"
-          }
-        },
         "properties": {
           "boundingBox": {
-            "$ref": "#/components/schemas/VideoPrompt/$defs/BoundingBox"
+            "$ref": "#/components/schemas/BoundingBox"
           },
           "cdnId": {
             "type": "string"
@@ -13512,6 +4991,37 @@
         ],
         "title": "VoiceAnswerPayload",
         "type": "object"
+      },
+      "Works": {
+        "properties": {
+          "value": {
+            "type": "string"
+          },
+          "visible": {
+            "type": "boolean"
+          }
+        },
+        "required": [
+          "value",
+          "visible"
+        ],
+        "type": "object"
+      },
+      "Zodiac": {
+        "properties": {
+          "value": {
+            "format": "int32",
+            "type": "integer"
+          },
+          "visible": {
+            "type": "boolean"
+          }
+        },
+        "required": [
+          "value",
+          "visible"
+        ],
+        "type": "object"
       }
     },
     "securitySchemes": {
@@ -13535,6 +5045,7 @@
   "info": {
     "description": "Unofficial typed Hinge REST and Sendbird chat API surface generated from hinge-rs.",
     "license": {
+      "identifier": "MIT OR Apache-2.0",
       "name": "MIT OR Apache-2.0"
     },
     "title": "hinge-rs",
@@ -13545,15 +5056,11 @@
     "/auth/device/validate": {
       "post": {
         "description": "Completes the email-device validation flow when OTP returns email 2FA.",
+        "operationId": "submitEmail2faCode",
         "parameters": [],
         "requestBody": {
           "content": {
             "application/json": {
-              "examples": {
-                "request": {
-                  "value": {}
-                }
-              },
               "schema": {
                 "$ref": "#/components/schemas/EmailCodeRequest"
               }
@@ -13565,11 +5072,6 @@
           "200": {
             "content": {
               "application/json": {
-                "examples": {
-                  "success": {
-                    "value": {}
-                  }
-                },
                 "schema": {
                   "$ref": "#/components/schemas/LoginTokens"
                 }
@@ -13646,6 +5148,7 @@
             "description": "Server error"
           }
         },
+        "security": [],
         "summary": "Submit email 2FA code",
         "tags": [
           "Auth"
@@ -13655,16 +5158,12 @@
     "/auth/settings": {
       "get": {
         "description": "Fetches auth settings.",
+        "operationId": "getAuthSettings",
         "parameters": [],
         "responses": {
           "200": {
             "content": {
               "application/json": {
-                "examples": {
-                  "success": {
-                    "value": {}
-                  }
-                },
                 "schema": {
                   "$ref": "#/components/schemas/AuthSettings"
                 }
@@ -13755,6 +5254,7 @@
     "/auth/sms/v2": {
       "post": {
         "description": "Exchanges a phone number and OTP for Hinge and Sendbird tokens. A 412 response means email 2FA is required.",
+        "operationId": "submitSmsOtp",
         "parameters": [],
         "requestBody": {
           "content": {
@@ -13871,6 +5371,7 @@
             "description": "Server error"
           }
         },
+        "security": [],
         "summary": "Submit SMS OTP",
         "tags": [
           "Auth"
@@ -13880,6 +5381,7 @@
     "/auth/sms/v2/initiate": {
       "post": {
         "description": "Starts the SMS OTP login flow for a phone number.",
+        "operationId": "initiateSmsLogin",
         "parameters": [],
         "requestBody": {
           "content": {
@@ -13903,11 +5405,6 @@
           "200": {
             "content": {
               "application/json": {
-                "examples": {
-                  "success": {
-                    "value": {}
-                  }
-                },
                 "schema": {
                   "$ref": "#/components/schemas/EmptyObject"
                 }
@@ -13984,6 +5481,7 @@
             "description": "Server error"
           }
         },
+        "security": [],
         "summary": "Initiate SMS login",
         "tags": [
           "Auth"
@@ -13993,6 +5491,7 @@
     "/connection/subject/{subjectId}": {
       "get": {
         "description": "Fetches full detail for a connection subject.",
+        "operationId": "getConnectionDetail",
         "parameters": [
           {
             "description": "Subject ID",
@@ -14008,11 +5507,6 @@
           "200": {
             "content": {
               "application/json": {
-                "examples": {
-                  "success": {
-                    "value": {}
-                  }
-                },
                 "schema": {
                   "$ref": "#/components/schemas/ConnectionDetailApi"
                 }
@@ -14103,16 +5597,12 @@
     "/connection/v2": {
       "get": {
         "description": "Fetches current connections/matches.",
+        "operationId": "listConnections",
         "parameters": [],
         "responses": {
           "200": {
             "content": {
               "application/json": {
-                "examples": {
-                  "success": {
-                    "value": {}
-                  }
-                },
                 "schema": {
                   "$ref": "#/components/schemas/ConnectionsResponse"
                 }
@@ -14203,6 +5693,7 @@
     "/connection/v2/matchnote/{subjectId}": {
       "get": {
         "description": "Fetches match note for a subject.",
+        "operationId": "getMatchNote",
         "parameters": [
           {
             "description": "Subject ID",
@@ -14315,6 +5806,7 @@
     "/content/v1": {
       "delete": {
         "description": "Deletes profile content by comma-separated content IDs.",
+        "operationId": "deleteContent",
         "parameters": [
           {
             "description": "Comma-separated content IDs",
@@ -14330,11 +5822,6 @@
           "200": {
             "content": {
               "application/json": {
-                "examples": {
-                  "success": {
-                    "value": {}
-                  }
-                },
                 "schema": {
                   "$ref": "#/components/schemas/EmptyObject"
                 }
@@ -14425,15 +5912,11 @@
     "/content/v1/answer/evaluate": {
       "post": {
         "description": "Runs Hinge answer review before saving prompt content.",
+        "operationId": "evaluateAnswer",
         "parameters": [],
         "requestBody": {
           "content": {
             "application/json": {
-              "examples": {
-                "request": {
-                  "value": {}
-                }
-              },
               "schema": {
                 "$ref": "#/components/schemas/AnswerEvaluateRequest"
               }
@@ -14445,11 +5928,6 @@
           "200": {
             "content": {
               "application/json": {
-                "examples": {
-                  "success": {
-                    "value": {}
-                  }
-                },
                 "schema": {
                   "$ref": "#/components/schemas/RawJson"
                 }
@@ -14540,15 +6018,11 @@
     "/content/v1/answers": {
       "put": {
         "description": "Replaces answer content.",
+        "operationId": "updateAnswers",
         "parameters": [],
         "requestBody": {
           "content": {
             "application/json": {
-              "examples": {
-                "request": {
-                  "value": {}
-                }
-              },
               "schema": {
                 "$ref": "#/components/schemas/AnswersUpdateRequest"
               }
@@ -14560,11 +6034,6 @@
           "200": {
             "content": {
               "application/json": {
-                "examples": {
-                  "success": {
-                    "value": {}
-                  }
-                },
                 "schema": {
                   "$ref": "#/components/schemas/RawJson"
                 }
@@ -14655,15 +6124,11 @@
     "/content/v1/prompt_poll": {
       "post": {
         "description": "Creates prompt poll content.",
+        "operationId": "createPromptPoll",
         "parameters": [],
         "requestBody": {
           "content": {
             "application/json": {
-              "examples": {
-                "request": {
-                  "value": {}
-                }
-              },
               "schema": {
                 "$ref": "#/components/schemas/CreatePromptPollRequest"
               }
@@ -14675,11 +6140,6 @@
           "200": {
             "content": {
               "application/json": {
-                "examples": {
-                  "success": {
-                    "value": {}
-                  }
-                },
                 "schema": {
                   "$ref": "#/components/schemas/CreatePromptPollResponse"
                 }
@@ -14770,16 +6230,12 @@
     "/content/v1/settings": {
       "get": {
         "description": "Fetches content settings.",
+        "operationId": "getContentSettings",
         "parameters": [],
         "responses": {
           "200": {
             "content": {
               "application/json": {
-                "examples": {
-                  "success": {
-                    "value": {}
-                  }
-                },
                 "schema": {
                   "$ref": "#/components/schemas/UserSettings"
                 }
@@ -14868,15 +6324,11 @@
       },
       "patch": {
         "description": "Updates content settings.",
+        "operationId": "updateContentSettings",
         "parameters": [],
         "requestBody": {
           "content": {
             "application/json": {
-              "examples": {
-                "request": {
-                  "value": {}
-                }
-              },
               "schema": {
                 "$ref": "#/components/schemas/UserSettings"
               }
@@ -14888,11 +6340,6 @@
           "200": {
             "content": {
               "application/json": {
-                "examples": {
-                  "success": {
-                    "value": {}
-                  }
-                },
                 "schema": {
                   "$ref": "#/components/schemas/RawJson"
                 }
@@ -14983,15 +6430,11 @@
     "/content/v1/video_prompt": {
       "post": {
         "description": "Creates video prompt content.",
+        "operationId": "createVideoPrompt",
         "parameters": [],
         "requestBody": {
           "content": {
             "application/json": {
-              "examples": {
-                "request": {
-                  "value": {}
-                }
-              },
               "schema": {
                 "$ref": "#/components/schemas/CreateVideoPromptRequest"
               }
@@ -15003,11 +6446,6 @@
           "200": {
             "content": {
               "application/json": {
-                "examples": {
-                  "success": {
-                    "value": {}
-                  }
-                },
                 "schema": {
                   "$ref": "#/components/schemas/CreateVideoPromptResponse"
                 }
@@ -15098,16 +6536,12 @@
     "/content/v2": {
       "get": {
         "description": "Fetches photos, prompts, and other profile content for the authenticated user.",
+        "operationId": "getSelfContent",
         "parameters": [],
         "responses": {
           "200": {
             "content": {
               "application/json": {
-                "examples": {
-                  "success": {
-                    "value": {}
-                  }
-                },
                 "schema": {
                   "$ref": "#/components/schemas/SelfContentResponse"
                 }
@@ -15198,6 +6632,7 @@
     "/content/v2/public": {
       "get": {
         "description": "Fetches public content records by comma-separated user IDs.",
+        "operationId": "getPublicProfileContent",
         "parameters": [
           {
             "description": "Comma-separated user IDs",
@@ -15213,11 +6648,6 @@
           "200": {
             "content": {
               "application/json": {
-                "examples": {
-                  "success": {
-                    "value": {}
-                  }
-                },
                 "schema": {
                   "$ref": "#/components/schemas/PublicContentResponse"
                 }
@@ -15308,6 +6738,7 @@
     "/flag/textreview": {
       "post": {
         "description": "Runs Hinge text review and returns an HCM run ID used when sending notes/likes with comments.",
+        "operationId": "reviewMessageText",
         "parameters": [],
         "requestBody": {
           "content": {
@@ -15331,11 +6762,6 @@
           "200": {
             "content": {
               "application/json": {
-                "examples": {
-                  "success": {
-                    "value": {}
-                  }
-                },
                 "schema": {
                   "$ref": "#/components/schemas/TextReviewResponse"
                 }
@@ -15426,15 +6852,11 @@
     "/group_channels": {
       "post": {
         "description": "Creates a distinct Sendbird group channel.",
+        "operationId": "createSendbirdDmChannel",
         "parameters": [],
         "requestBody": {
           "content": {
             "application/json": {
-              "examples": {
-                "request": {
-                  "value": {}
-                }
-              },
               "schema": {
                 "$ref": "#/components/schemas/SendbirdCreateChannelRequest"
               }
@@ -15446,11 +6868,6 @@
           "200": {
             "content": {
               "application/json": {
-                "examples": {
-                  "success": {
-                    "value": {}
-                  }
-                },
                 "schema": {
                   "$ref": "#/components/schemas/RawJson"
                 }
@@ -15541,6 +6958,7 @@
     "/group_channels/{channelUrl}/messages": {
       "get": {
         "description": "Fetches message history around an optional timestamp anchor.",
+        "operationId": "getSendbirdMessages",
         "parameters": [
           {
             "description": "URL-encoded channel URL",
@@ -15574,11 +6992,6 @@
           "200": {
             "content": {
               "application/json": {
-                "examples": {
-                  "success": {
-                    "value": {}
-                  }
-                },
                 "schema": {
                   "$ref": "#/components/schemas/SendbirdMessagesResponse"
                 }
@@ -15669,6 +7082,7 @@
     "/identity/install": {
       "post": {
         "description": "Registers a generated install ID before SMS login.",
+        "operationId": "registerDeviceInstall",
         "parameters": [],
         "requestBody": {
           "content": {
@@ -15691,11 +7105,6 @@
           "200": {
             "content": {
               "application/json": {
-                "examples": {
-                  "success": {
-                    "value": {}
-                  }
-                },
                 "schema": {
                   "$ref": "#/components/schemas/EmptyObject"
                 }
@@ -15772,6 +7181,7 @@
             "description": "Server error"
           }
         },
+        "security": [],
         "summary": "Register device install",
         "tags": [
           "Auth"
@@ -15781,6 +7191,7 @@
     "/like/subject/{subjectId}": {
       "get": {
         "description": "Fetches one like by subject ID.",
+        "operationId": "getLikeSubject",
         "parameters": [
           {
             "description": "Subject ID",
@@ -15796,11 +7207,6 @@
           "200": {
             "content": {
               "application/json": {
-                "examples": {
-                  "success": {
-                    "value": {}
-                  }
-                },
                 "schema": {
                   "$ref": "#/components/schemas/LikeItemV2"
                 }
@@ -15891,16 +7297,12 @@
     "/like/v2": {
       "get": {
         "description": "Fetches inbound likes.",
+        "operationId": "listLikes",
         "parameters": [],
         "responses": {
           "200": {
             "content": {
               "application/json": {
-                "examples": {
-                  "success": {
-                    "value": {}
-                  }
-                },
                 "schema": {
                   "$ref": "#/components/schemas/LikesV2Response"
                 }
@@ -15991,6 +7393,7 @@
     "/likelimit": {
       "get": {
         "description": "Fetches remaining standard and super likes.",
+        "operationId": "getLikeLimit",
         "parameters": [],
         "responses": {
           "200": {
@@ -16094,6 +7497,7 @@
     "/message/authenticate": {
       "post": {
         "description": "Exchanges Hinge auth for a Sendbird JWT.",
+        "operationId": "authenticateSendbird",
         "parameters": [],
         "requestBody": {
           "content": {
@@ -16214,6 +7618,7 @@
     "/message/send": {
       "post": {
         "description": "Sends a message through Hinge after ensuring a Sendbird DM channel exists.",
+        "operationId": "sendHingeMessage",
         "parameters": [],
         "requestBody": {
           "content": {
@@ -16243,11 +7648,6 @@
           "200": {
             "content": {
               "application/json": {
-                "examples": {
-                  "success": {
-                    "value": {}
-                  }
-                },
                 "schema": {
                   "$ref": "#/components/schemas/RawJson"
                 }
@@ -16338,16 +7738,12 @@
     "/notification/v1/settings": {
       "get": {
         "description": "Fetches notification settings.",
+        "operationId": "getNotificationSettings",
         "parameters": [],
         "responses": {
           "200": {
             "content": {
               "application/json": {
-                "examples": {
-                  "success": {
-                    "value": {}
-                  }
-                },
                 "schema": {
                   "$ref": "#/components/schemas/NotificationSettings"
                 }
@@ -16438,16 +7834,12 @@
     "/preference/v2/selected": {
       "get": {
         "description": "Fetches selected dating preferences.",
+        "operationId": "getSelfPreferences",
         "parameters": [],
         "responses": {
           "200": {
             "content": {
               "application/json": {
-                "examples": {
-                  "success": {
-                    "value": {}
-                  }
-                },
                 "schema": {
                   "$ref": "#/components/schemas/PreferencesResponse"
                 }
@@ -16536,15 +7928,11 @@
       },
       "patch": {
         "description": "Updates selected dating preferences.",
+        "operationId": "updateSelfPreferences",
         "parameters": [],
         "requestBody": {
           "content": {
             "application/json": {
-              "examples": {
-                "request": {
-                  "value": {}
-                }
-              },
               "schema": {
                 "$ref": "#/components/schemas/PreferencesUpdateRequest"
               }
@@ -16556,11 +7944,6 @@
           "200": {
             "content": {
               "application/json": {
-                "examples": {
-                  "success": {
-                    "value": {}
-                  }
-                },
                 "schema": {
                   "$ref": "#/components/schemas/RawJson"
                 }
@@ -16651,15 +8034,11 @@
     "/prompts": {
       "post": {
         "description": "Fetches prompt catalog using a payload derived from profile and preferences.",
+        "operationId": "listPrompts",
         "parameters": [],
         "requestBody": {
           "content": {
             "application/json": {
-              "examples": {
-                "request": {
-                  "value": {}
-                }
-              },
               "schema": {
                 "$ref": "#/components/schemas/PromptPayload"
               }
@@ -16671,11 +8050,6 @@
           "200": {
             "content": {
               "application/json": {
-                "examples": {
-                  "success": {
-                    "value": {}
-                  }
-                },
                 "schema": {
                   "$ref": "#/components/schemas/PromptsResponse"
                 }
@@ -16766,15 +8140,11 @@
     "/rate/v2/initiate": {
       "post": {
         "description": "Creates a like, note, superlike, or skip rating.",
+        "operationId": "rateOrSkipUser",
         "parameters": [],
         "requestBody": {
           "content": {
             "application/json": {
-              "examples": {
-                "request": {
-                  "value": {}
-                }
-              },
               "schema": {
                 "$ref": "#/components/schemas/CreateRate"
               }
@@ -16786,11 +8156,6 @@
           "200": {
             "content": {
               "application/json": {
-                "examples": {
-                  "success": {
-                    "value": {}
-                  }
-                },
                 "schema": {
                   "$ref": "#/components/schemas/LikeResponse"
                 }
@@ -16881,15 +8246,11 @@
     "/rate/v2/respond": {
       "post": {
         "description": "Responds to an inbound like/match flow.",
+        "operationId": "respondToRate",
         "parameters": [],
         "requestBody": {
           "content": {
             "application/json": {
-              "examples": {
-                "request": {
-                  "value": {}
-                }
-              },
               "schema": {
                 "$ref": "#/components/schemas/RateRespondRequest"
               }
@@ -16901,11 +8262,6 @@
           "200": {
             "content": {
               "application/json": {
-                "examples": {
-                  "success": {
-                    "value": {}
-                  }
-                },
                 "schema": {
                   "$ref": "#/components/schemas/RateRespondResponse"
                 }
@@ -16996,6 +8352,7 @@
     "/rec/v2": {
       "post": {
         "description": "Fetches recommendation feeds for the authenticated user.",
+        "operationId": "getRecommendations",
         "parameters": [],
         "requestBody": {
           "content": {
@@ -17020,11 +8377,6 @@
           "200": {
             "content": {
               "application/json": {
-                "examples": {
-                  "success": {
-                    "value": {}
-                  }
-                },
                 "schema": {
                   "$ref": "#/components/schemas/RecommendationsResponse"
                 }
@@ -17115,15 +8467,11 @@
     "/sdk/chat/export": {
       "post": {
         "description": "SDK helper that fetches channel/profile context and writes a local markdown export. This is not a remote Hinge endpoint.",
+        "operationId": "exportChatHelper",
         "parameters": [],
         "requestBody": {
           "content": {
             "application/json": {
-              "examples": {
-                "request": {
-                  "value": {}
-                }
-              },
               "schema": {
                 "$ref": "#/components/schemas/ExportChatInput"
               }
@@ -17135,11 +8483,6 @@
           "200": {
             "content": {
               "application/json": {
-                "examples": {
-                  "success": {
-                    "value": {}
-                  }
-                },
                 "schema": {
                   "$ref": "#/components/schemas/ExportChatResult"
                 }
@@ -17230,6 +8573,7 @@
     "/sdk/group_channels/{channelUrl}": {
       "get": {
         "description": "Fetches a Sendbird group channel using the SDK endpoint.",
+        "operationId": "getSendbirdChannel",
         "parameters": [
           {
             "description": "URL-encoded channel URL",
@@ -17245,11 +8589,6 @@
           "200": {
             "content": {
               "application/json": {
-                "examples": {
-                  "success": {
-                    "value": {}
-                  }
-                },
                 "schema": {
                   "$ref": "#/components/schemas/SendbirdGroupChannel"
                 }
@@ -17340,9 +8679,27 @@
     "/sendbird/ws": {
       "get": {
         "description": "Pseudo-operation documenting the Sendbird WebSocket handshake and typed events. The Rust client connects to wss://ws-{appId}.sendbird.com/.",
+        "operationId": "connectSendbirdWebSocket",
         "responses": {
           "101": {
             "description": "WebSocket upgrade accepted"
+          },
+          "401": {
+            "content": {
+              "application/json": {
+                "examples": {
+                  "error": {
+                    "value": {
+                      "error": "Unauthorized"
+                    }
+                  }
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            },
+            "description": "Unauthorized"
           }
         },
         "security": [
@@ -17379,16 +8736,12 @@
     "/standouts/v3": {
       "get": {
         "description": "Fetches standout recommendations.",
+        "operationId": "getStandouts",
         "parameters": [],
         "responses": {
           "200": {
             "content": {
               "application/json": {
-                "examples": {
-                  "success": {
-                    "value": {}
-                  }
-                },
                 "schema": {
                   "$ref": "#/components/schemas/StandoutsResponse"
                 }
@@ -17479,16 +8832,12 @@
     "/store/v2/account": {
       "get": {
         "description": "Fetches account and subscription information.",
+        "operationId": "getAccountInfo",
         "parameters": [],
         "responses": {
           "200": {
             "content": {
               "application/json": {
-                "examples": {
-                  "success": {
-                    "value": {}
-                  }
-                },
                 "schema": {
                   "$ref": "#/components/schemas/AccountInfo"
                 }
@@ -17579,16 +8928,12 @@
     "/user/export/status": {
       "get": {
         "description": "Fetches account data export status.",
+        "operationId": "getExportStatus",
         "parameters": [],
         "responses": {
           "200": {
             "content": {
               "application/json": {
-                "examples": {
-                  "success": {
-                    "value": {}
-                  }
-                },
                 "schema": {
                   "$ref": "#/components/schemas/ExportStatus"
                 }
@@ -17679,16 +9024,12 @@
     "/user/repeat": {
       "get": {
         "description": "Requests repeated profiles from Hinge.",
+        "operationId": "repeatProfiles",
         "parameters": [],
         "responses": {
           "200": {
             "content": {
               "application/json": {
-                "examples": {
-                  "success": {
-                    "value": {}
-                  }
-                },
                 "schema": {
                   "$ref": "#/components/schemas/RawJson"
                 }
@@ -17779,16 +9120,12 @@
     "/user/v2/traits": {
       "get": {
         "description": "Fetches user traits.",
+        "operationId": "getUserTraits",
         "parameters": [],
         "responses": {
           "200": {
             "content": {
               "application/json": {
-                "examples": {
-                  "success": {
-                    "value": {}
-                  }
-                },
                 "schema": {
                   "$ref": "#/components/schemas/UserTraitsResponse"
                 }
@@ -17879,16 +9216,12 @@
     "/user/v3": {
       "get": {
         "description": "Fetches the authenticated user's profile.",
+        "operationId": "getSelfProfile",
         "parameters": [],
         "responses": {
           "200": {
             "content": {
               "application/json": {
-                "examples": {
-                  "success": {
-                    "value": {}
-                  }
-                },
                 "schema": {
                   "$ref": "#/components/schemas/SelfProfileResponse"
                 }
@@ -17977,15 +9310,11 @@
       },
       "patch": {
         "description": "Applies profile updates using Hinge's numeric enum wire format.",
+        "operationId": "updateSelfProfile",
         "parameters": [],
         "requestBody": {
           "content": {
             "application/json": {
-              "examples": {
-                "request": {
-                  "value": {}
-                }
-              },
               "schema": {
                 "$ref": "#/components/schemas/ProfileUpdateRequest"
               }
@@ -17997,11 +9326,6 @@
           "200": {
             "content": {
               "application/json": {
-                "examples": {
-                  "success": {
-                    "value": {}
-                  }
-                },
                 "schema": {
                   "$ref": "#/components/schemas/RawJson"
                 }
@@ -18092,6 +9416,7 @@
     "/user/v3/public": {
       "get": {
         "description": "Fetches public profile records by comma-separated user IDs.",
+        "operationId": "getPublicProfiles",
         "parameters": [
           {
             "description": "Comma-separated user IDs",
@@ -18107,11 +9432,6 @@
           "200": {
             "content": {
               "application/json": {
-                "examples": {
-                  "success": {
-                    "value": {}
-                  }
-                },
                 "schema": {
                   "$ref": "#/components/schemas/PublicProfilesResponse"
                 }
@@ -18202,6 +9522,7 @@
     "/users/{userId}/my_group_channels": {
       "get": {
         "description": "Lists Sendbird group channels for the authenticated user using the mobile SDK query shape.",
+        "operationId": "listMySendbirdChannels",
         "parameters": [
           {
             "description": "Sendbird user ID",
@@ -18253,11 +9574,6 @@
           "200": {
             "content": {
               "application/json": {
-                "examples": {
-                  "success": {
-                    "value": {}
-                  }
-                },
                 "schema": {
                   "$ref": "#/components/schemas/SendbirdChannelsResponse"
                 }
@@ -18363,36 +9679,47 @@
   ],
   "tags": [
     {
+      "description": "Device install, SMS OTP, email 2FA, and auth settings.",
       "name": "Auth"
     },
     {
+      "description": "Recommendation feeds, standouts, and repeat profiles.",
       "name": "Recommendations"
     },
     {
+      "description": "Self, public, and profile-content APIs.",
       "name": "Profiles"
     },
     {
+      "description": "Inbound likes, like limits, and like subject lookup.",
       "name": "Likes"
     },
     {
+      "description": "Like, note, superlike, skip, and response flows.",
       "name": "Ratings"
     },
     {
+      "description": "Prompt catalog and prompt-content creation.",
       "name": "Prompts"
     },
     {
+      "description": "Matches, connection detail, and match notes.",
       "name": "Connections"
     },
     {
+      "description": "Preferences, notifications, user traits, account, and export status.",
       "name": "Settings"
     },
     {
+      "description": "Hinge chat helpers and local export support.",
       "name": "Chat"
     },
     {
+      "description": "Sendbird channel, message, and group-channel endpoints used by Hinge chat.",
       "name": "Sendbird REST"
     },
     {
+      "description": "Documented Sendbird WebSocket handshake and typed frame events.",
       "name": "Sendbird WebSocket"
     }
   ],

--- a/openapi/hinge-api.openapi.json
+++ b/openapi/hinge-api.openapi.json
@@ -39,35 +39,6 @@
         "type": "object"
       },
       "AnswerContentPayload": {
-        "$defs": {
-          "VoiceAnswerPayload": {
-            "properties": {
-              "cdnId": {
-                "type": "string"
-              },
-              "cdnUrl": {
-                "type": "string"
-              },
-              "type": {
-                "type": "string"
-              },
-              "url": {
-                "type": "string"
-              },
-              "waveform": {
-                "type": "string"
-              }
-            },
-            "required": [
-              "cdnUrl",
-              "waveform",
-              "type",
-              "cdnId",
-              "url"
-            ],
-            "type": "object"
-          }
-        },
         "properties": {
           "position": {
             "format": "int32",
@@ -80,7 +51,7 @@
           "voiceAnswer": {
             "anyOf": [
               {
-                "$ref": "#/components/schemas/AnswerContentPayload/$defs/VoiceAnswerPayload"
+                "$ref": "#/components/schemas/VoiceAnswerPayload"
               },
               {
                 "type": "null"
@@ -142,33 +113,16 @@
         "type": "object"
       },
       "BoundingBox": {
-        "$defs": {
-          "Coordinate": {
-            "properties": {
-              "x": {
-                "default": 0.0,
-                "format": "double",
-                "type": "number"
-              },
-              "y": {
-                "default": 0.0,
-                "format": "double",
-                "type": "number"
-              }
-            },
-            "type": "object"
-          }
-        },
         "properties": {
           "bottomRight": {
-            "$ref": "#/components/schemas/BoundingBox/$defs/Coordinate",
+            "$ref": "#/components/schemas/Coordinate",
             "default": {
               "x": 0.0,
               "y": 0.0
             }
           },
           "topLeft": {
-            "$ref": "#/components/schemas/BoundingBox/$defs/Coordinate",
+            "$ref": "#/components/schemas/Coordinate",
             "default": {
               "x": 0.0,
               "y": 0.0
@@ -178,198 +132,38 @@
         "title": "BoundingBox",
         "type": "object"
       },
-      "ConnectionContentItem": {
-        "$defs": {
-          "BoundingBox": {
-            "properties": {
-              "bottomRight": {
-                "$ref": "#/components/schemas/ConnectionContentItem/$defs/Coordinate",
-                "default": {
-                  "x": 0.0,
-                  "y": 0.0
-                }
-              },
-              "topLeft": {
-                "$ref": "#/components/schemas/ConnectionContentItem/$defs/Coordinate",
-                "default": {
-                  "x": 0.0,
-                  "y": 0.0
-                }
-              }
-            },
-            "type": "object"
+      "ChildrenStatus": {
+        "properties": {
+          "value": {
+            "$ref": "#/components/schemas/ChildrenStatusProfile"
           },
-          "ConnectionPrompt": {
-            "properties": {
-              "answer": {
-                "default": "",
-                "type": "string"
-              },
-              "contentId": {
-                "type": [
-                  "string",
-                  "null"
-                ]
-              },
-              "question": {
-                "default": "",
-                "type": "string"
-              }
-            },
-            "type": "object"
-          },
-          "ConnectionVideo": {
-            "properties": {
-              "boundingBox": {
-                "anyOf": [
-                  {
-                    "$ref": "#/components/schemas/ConnectionContentItem/$defs/BoundingBox"
-                  },
-                  {
-                    "type": "null"
-                  }
-                ]
-              },
-              "cdnId": {
-                "type": [
-                  "string",
-                  "null"
-                ]
-              },
-              "contentId": {
-                "type": [
-                  "string",
-                  "null"
-                ]
-              },
-              "thumbnail": {
-                "default": "",
-                "type": "string"
-              },
-              "url": {
-                "default": "",
-                "type": "string"
-              }
-            },
-            "type": "object"
-          },
-          "Coordinate": {
-            "properties": {
-              "x": {
-                "default": 0.0,
-                "format": "double",
-                "type": "number"
-              },
-              "y": {
-                "default": 0.0,
-                "format": "double",
-                "type": "number"
-              }
-            },
-            "type": "object"
-          },
-          "PhotoAsset": {
-            "properties": {
-              "boundingBox": {
-                "anyOf": [
-                  {
-                    "$ref": "#/components/schemas/ConnectionContentItem/$defs/BoundingBox"
-                  },
-                  {
-                    "type": "null"
-                  }
-                ]
-              },
-              "caption": {
-                "type": [
-                  "string",
-                  "null"
-                ]
-              },
-              "cdnId": {
-                "type": [
-                  "string",
-                  "null"
-                ]
-              },
-              "contentId": {
-                "type": [
-                  "string",
-                  "null"
-                ]
-              },
-              "height": {
-                "format": "int32",
-                "type": [
-                  "integer",
-                  "null"
-                ]
-              },
-              "id": {
-                "type": [
-                  "string",
-                  "null"
-                ]
-              },
-              "location": {
-                "type": [
-                  "string",
-                  "null"
-                ]
-              },
-              "pHash": {
-                "type": [
-                  "string",
-                  "null"
-                ]
-              },
-              "promptId": {
-                "type": [
-                  "string",
-                  "null"
-                ]
-              },
-              "selfieVerified": {
-                "type": [
-                  "boolean",
-                  "null"
-                ]
-              },
-              "source": {
-                "type": [
-                  "string",
-                  "null"
-                ]
-              },
-              "sourceId": {
-                "type": [
-                  "string",
-                  "null"
-                ]
-              },
-              "url": {
-                "type": "string"
-              },
-              "videoUrl": {
-                "type": [
-                  "string",
-                  "null"
-                ]
-              },
-              "width": {
-                "format": "int32",
-                "type": [
-                  "integer",
-                  "null"
-                ]
-              }
-            },
-            "required": [
-              "url"
-            ],
-            "type": "object"
+          "visible": {
+            "type": "boolean"
           }
         },
+        "required": [
+          "value",
+          "visible"
+        ],
+        "type": "object"
+      },
+      "ChildrenStatusPreference": {
+        "enum": [
+          "OpenToAll",
+          "No",
+          "Yes"
+        ],
+        "type": "string"
+      },
+      "ChildrenStatusProfile": {
+        "enum": [
+          "PreferNotToSay",
+          "No",
+          "Yes"
+        ],
+        "type": "string"
+      },
+      "ConnectionContentItem": {
         "properties": {
           "comment": {
             "type": [
@@ -380,7 +174,7 @@
           "photo": {
             "anyOf": [
               {
-                "$ref": "#/components/schemas/ConnectionContentItem/$defs/PhotoAsset"
+                "$ref": "#/components/schemas/PhotoAsset"
               },
               {
                 "type": "null"
@@ -390,7 +184,7 @@
           "prompt": {
             "anyOf": [
               {
-                "$ref": "#/components/schemas/ConnectionContentItem/$defs/ConnectionPrompt"
+                "$ref": "#/components/schemas/ConnectionPrompt"
               },
               {
                 "type": "null"
@@ -400,7 +194,7 @@
           "video": {
             "anyOf": [
               {
-                "$ref": "#/components/schemas/ConnectionContentItem/$defs/ConnectionVideo"
+                "$ref": "#/components/schemas/ConnectionVideo"
               },
               {
                 "type": "null"
@@ -412,238 +206,6 @@
         "type": "object"
       },
       "ConnectionDetailApi": {
-        "$defs": {
-          "BoundingBox": {
-            "properties": {
-              "bottomRight": {
-                "$ref": "#/components/schemas/ConnectionDetailApi/$defs/Coordinate",
-                "default": {
-                  "x": 0.0,
-                  "y": 0.0
-                }
-              },
-              "topLeft": {
-                "$ref": "#/components/schemas/ConnectionDetailApi/$defs/Coordinate",
-                "default": {
-                  "x": 0.0,
-                  "y": 0.0
-                }
-              }
-            },
-            "type": "object"
-          },
-          "ConnectionContentItem": {
-            "properties": {
-              "comment": {
-                "type": [
-                  "string",
-                  "null"
-                ]
-              },
-              "photo": {
-                "anyOf": [
-                  {
-                    "$ref": "#/components/schemas/ConnectionDetailApi/$defs/PhotoAsset"
-                  },
-                  {
-                    "type": "null"
-                  }
-                ]
-              },
-              "prompt": {
-                "anyOf": [
-                  {
-                    "$ref": "#/components/schemas/ConnectionDetailApi/$defs/ConnectionPrompt"
-                  },
-                  {
-                    "type": "null"
-                  }
-                ]
-              },
-              "video": {
-                "anyOf": [
-                  {
-                    "$ref": "#/components/schemas/ConnectionDetailApi/$defs/ConnectionVideo"
-                  },
-                  {
-                    "type": "null"
-                  }
-                ]
-              }
-            },
-            "type": "object"
-          },
-          "ConnectionPrompt": {
-            "properties": {
-              "answer": {
-                "default": "",
-                "type": "string"
-              },
-              "contentId": {
-                "type": [
-                  "string",
-                  "null"
-                ]
-              },
-              "question": {
-                "default": "",
-                "type": "string"
-              }
-            },
-            "type": "object"
-          },
-          "ConnectionVideo": {
-            "properties": {
-              "boundingBox": {
-                "anyOf": [
-                  {
-                    "$ref": "#/components/schemas/ConnectionDetailApi/$defs/BoundingBox"
-                  },
-                  {
-                    "type": "null"
-                  }
-                ]
-              },
-              "cdnId": {
-                "type": [
-                  "string",
-                  "null"
-                ]
-              },
-              "contentId": {
-                "type": [
-                  "string",
-                  "null"
-                ]
-              },
-              "thumbnail": {
-                "default": "",
-                "type": "string"
-              },
-              "url": {
-                "default": "",
-                "type": "string"
-              }
-            },
-            "type": "object"
-          },
-          "Coordinate": {
-            "properties": {
-              "x": {
-                "default": 0.0,
-                "format": "double",
-                "type": "number"
-              },
-              "y": {
-                "default": 0.0,
-                "format": "double",
-                "type": "number"
-              }
-            },
-            "type": "object"
-          },
-          "PhotoAsset": {
-            "properties": {
-              "boundingBox": {
-                "anyOf": [
-                  {
-                    "$ref": "#/components/schemas/ConnectionDetailApi/$defs/BoundingBox"
-                  },
-                  {
-                    "type": "null"
-                  }
-                ]
-              },
-              "caption": {
-                "type": [
-                  "string",
-                  "null"
-                ]
-              },
-              "cdnId": {
-                "type": [
-                  "string",
-                  "null"
-                ]
-              },
-              "contentId": {
-                "type": [
-                  "string",
-                  "null"
-                ]
-              },
-              "height": {
-                "format": "int32",
-                "type": [
-                  "integer",
-                  "null"
-                ]
-              },
-              "id": {
-                "type": [
-                  "string",
-                  "null"
-                ]
-              },
-              "location": {
-                "type": [
-                  "string",
-                  "null"
-                ]
-              },
-              "pHash": {
-                "type": [
-                  "string",
-                  "null"
-                ]
-              },
-              "promptId": {
-                "type": [
-                  "string",
-                  "null"
-                ]
-              },
-              "selfieVerified": {
-                "type": [
-                  "boolean",
-                  "null"
-                ]
-              },
-              "source": {
-                "type": [
-                  "string",
-                  "null"
-                ]
-              },
-              "sourceId": {
-                "type": [
-                  "string",
-                  "null"
-                ]
-              },
-              "url": {
-                "type": "string"
-              },
-              "videoUrl": {
-                "type": [
-                  "string",
-                  "null"
-                ]
-              },
-              "width": {
-                "format": "int32",
-                "type": [
-                  "integer",
-                  "null"
-                ]
-              }
-            },
-            "required": [
-              "url"
-            ],
-            "type": "object"
-          }
-        },
         "properties": {
           "initiatedWith": {
             "default": "",
@@ -666,7 +228,7 @@
           "sentContent": {
             "default": [],
             "items": {
-              "$ref": "#/components/schemas/ConnectionDetailApi/$defs/ConnectionContentItem"
+              "$ref": "#/components/schemas/ConnectionContentItem"
             },
             "type": "array"
           },
@@ -701,238 +263,6 @@
         "type": "object"
       },
       "ConnectionItem": {
-        "$defs": {
-          "BoundingBox": {
-            "properties": {
-              "bottomRight": {
-                "$ref": "#/components/schemas/ConnectionItem/$defs/Coordinate",
-                "default": {
-                  "x": 0.0,
-                  "y": 0.0
-                }
-              },
-              "topLeft": {
-                "$ref": "#/components/schemas/ConnectionItem/$defs/Coordinate",
-                "default": {
-                  "x": 0.0,
-                  "y": 0.0
-                }
-              }
-            },
-            "type": "object"
-          },
-          "ConnectionContentItem": {
-            "properties": {
-              "comment": {
-                "type": [
-                  "string",
-                  "null"
-                ]
-              },
-              "photo": {
-                "anyOf": [
-                  {
-                    "$ref": "#/components/schemas/ConnectionItem/$defs/PhotoAsset"
-                  },
-                  {
-                    "type": "null"
-                  }
-                ]
-              },
-              "prompt": {
-                "anyOf": [
-                  {
-                    "$ref": "#/components/schemas/ConnectionItem/$defs/ConnectionPrompt"
-                  },
-                  {
-                    "type": "null"
-                  }
-                ]
-              },
-              "video": {
-                "anyOf": [
-                  {
-                    "$ref": "#/components/schemas/ConnectionItem/$defs/ConnectionVideo"
-                  },
-                  {
-                    "type": "null"
-                  }
-                ]
-              }
-            },
-            "type": "object"
-          },
-          "ConnectionPrompt": {
-            "properties": {
-              "answer": {
-                "default": "",
-                "type": "string"
-              },
-              "contentId": {
-                "type": [
-                  "string",
-                  "null"
-                ]
-              },
-              "question": {
-                "default": "",
-                "type": "string"
-              }
-            },
-            "type": "object"
-          },
-          "ConnectionVideo": {
-            "properties": {
-              "boundingBox": {
-                "anyOf": [
-                  {
-                    "$ref": "#/components/schemas/ConnectionItem/$defs/BoundingBox"
-                  },
-                  {
-                    "type": "null"
-                  }
-                ]
-              },
-              "cdnId": {
-                "type": [
-                  "string",
-                  "null"
-                ]
-              },
-              "contentId": {
-                "type": [
-                  "string",
-                  "null"
-                ]
-              },
-              "thumbnail": {
-                "default": "",
-                "type": "string"
-              },
-              "url": {
-                "default": "",
-                "type": "string"
-              }
-            },
-            "type": "object"
-          },
-          "Coordinate": {
-            "properties": {
-              "x": {
-                "default": 0.0,
-                "format": "double",
-                "type": "number"
-              },
-              "y": {
-                "default": 0.0,
-                "format": "double",
-                "type": "number"
-              }
-            },
-            "type": "object"
-          },
-          "PhotoAsset": {
-            "properties": {
-              "boundingBox": {
-                "anyOf": [
-                  {
-                    "$ref": "#/components/schemas/ConnectionItem/$defs/BoundingBox"
-                  },
-                  {
-                    "type": "null"
-                  }
-                ]
-              },
-              "caption": {
-                "type": [
-                  "string",
-                  "null"
-                ]
-              },
-              "cdnId": {
-                "type": [
-                  "string",
-                  "null"
-                ]
-              },
-              "contentId": {
-                "type": [
-                  "string",
-                  "null"
-                ]
-              },
-              "height": {
-                "format": "int32",
-                "type": [
-                  "integer",
-                  "null"
-                ]
-              },
-              "id": {
-                "type": [
-                  "string",
-                  "null"
-                ]
-              },
-              "location": {
-                "type": [
-                  "string",
-                  "null"
-                ]
-              },
-              "pHash": {
-                "type": [
-                  "string",
-                  "null"
-                ]
-              },
-              "promptId": {
-                "type": [
-                  "string",
-                  "null"
-                ]
-              },
-              "selfieVerified": {
-                "type": [
-                  "boolean",
-                  "null"
-                ]
-              },
-              "source": {
-                "type": [
-                  "string",
-                  "null"
-                ]
-              },
-              "sourceId": {
-                "type": [
-                  "string",
-                  "null"
-                ]
-              },
-              "url": {
-                "type": "string"
-              },
-              "videoUrl": {
-                "type": [
-                  "string",
-                  "null"
-                ]
-              },
-              "width": {
-                "format": "int32",
-                "type": [
-                  "integer",
-                  "null"
-                ]
-              }
-            },
-            "required": [
-              "url"
-            ],
-            "type": "object"
-          }
-        },
         "properties": {
           "initiatedWith": {
             "default": "",
@@ -955,7 +285,7 @@
           "sentContent": {
             "default": [],
             "items": {
-              "$ref": "#/components/schemas/ConnectionItem/$defs/ConnectionContentItem"
+              "$ref": "#/components/schemas/ConnectionContentItem"
             },
             "type": "array"
           },
@@ -1004,47 +334,11 @@
         "type": "object"
       },
       "ConnectionVideo": {
-        "$defs": {
-          "BoundingBox": {
-            "properties": {
-              "bottomRight": {
-                "$ref": "#/components/schemas/ConnectionVideo/$defs/Coordinate",
-                "default": {
-                  "x": 0.0,
-                  "y": 0.0
-                }
-              },
-              "topLeft": {
-                "$ref": "#/components/schemas/ConnectionVideo/$defs/Coordinate",
-                "default": {
-                  "x": 0.0,
-                  "y": 0.0
-                }
-              }
-            },
-            "type": "object"
-          },
-          "Coordinate": {
-            "properties": {
-              "x": {
-                "default": 0.0,
-                "format": "double",
-                "type": "number"
-              },
-              "y": {
-                "default": 0.0,
-                "format": "double",
-                "type": "number"
-              }
-            },
-            "type": "object"
-          }
-        },
         "properties": {
           "boundingBox": {
             "anyOf": [
               {
-                "$ref": "#/components/schemas/ConnectionVideo/$defs/BoundingBox"
+                "$ref": "#/components/schemas/BoundingBox"
               },
               {
                 "type": "null"
@@ -1076,293 +370,11 @@
         "type": "object"
       },
       "ConnectionsResponse": {
-        "$defs": {
-          "BoundingBox": {
-            "properties": {
-              "bottomRight": {
-                "$ref": "#/components/schemas/ConnectionsResponse/$defs/Coordinate",
-                "default": {
-                  "x": 0.0,
-                  "y": 0.0
-                }
-              },
-              "topLeft": {
-                "$ref": "#/components/schemas/ConnectionsResponse/$defs/Coordinate",
-                "default": {
-                  "x": 0.0,
-                  "y": 0.0
-                }
-              }
-            },
-            "type": "object"
-          },
-          "ConnectionContentItem": {
-            "properties": {
-              "comment": {
-                "type": [
-                  "string",
-                  "null"
-                ]
-              },
-              "photo": {
-                "anyOf": [
-                  {
-                    "$ref": "#/components/schemas/ConnectionsResponse/$defs/PhotoAsset"
-                  },
-                  {
-                    "type": "null"
-                  }
-                ]
-              },
-              "prompt": {
-                "anyOf": [
-                  {
-                    "$ref": "#/components/schemas/ConnectionsResponse/$defs/ConnectionPrompt"
-                  },
-                  {
-                    "type": "null"
-                  }
-                ]
-              },
-              "video": {
-                "anyOf": [
-                  {
-                    "$ref": "#/components/schemas/ConnectionsResponse/$defs/ConnectionVideo"
-                  },
-                  {
-                    "type": "null"
-                  }
-                ]
-              }
-            },
-            "type": "object"
-          },
-          "ConnectionItem": {
-            "properties": {
-              "initiatedWith": {
-                "default": "",
-                "type": "string"
-              },
-              "initiatorId": {
-                "default": "",
-                "type": "string"
-              },
-              "isHidden": {
-                "default": false,
-                "type": "boolean"
-              },
-              "receivedTime": {
-                "type": [
-                  "string",
-                  "null"
-                ]
-              },
-              "sentContent": {
-                "default": [],
-                "items": {
-                  "$ref": "#/components/schemas/ConnectionsResponse/$defs/ConnectionContentItem"
-                },
-                "type": "array"
-              },
-              "sentTime": {
-                "type": [
-                  "string",
-                  "null"
-                ]
-              },
-              "socialMediaExchangedTimestamp": {
-                "type": [
-                  "string",
-                  "null"
-                ]
-              },
-              "source": {
-                "default": "",
-                "type": "string"
-              },
-              "subjectId": {
-                "default": "",
-                "type": "string"
-              }
-            },
-            "type": "object"
-          },
-          "ConnectionPrompt": {
-            "properties": {
-              "answer": {
-                "default": "",
-                "type": "string"
-              },
-              "contentId": {
-                "type": [
-                  "string",
-                  "null"
-                ]
-              },
-              "question": {
-                "default": "",
-                "type": "string"
-              }
-            },
-            "type": "object"
-          },
-          "ConnectionVideo": {
-            "properties": {
-              "boundingBox": {
-                "anyOf": [
-                  {
-                    "$ref": "#/components/schemas/ConnectionsResponse/$defs/BoundingBox"
-                  },
-                  {
-                    "type": "null"
-                  }
-                ]
-              },
-              "cdnId": {
-                "type": [
-                  "string",
-                  "null"
-                ]
-              },
-              "contentId": {
-                "type": [
-                  "string",
-                  "null"
-                ]
-              },
-              "thumbnail": {
-                "default": "",
-                "type": "string"
-              },
-              "url": {
-                "default": "",
-                "type": "string"
-              }
-            },
-            "type": "object"
-          },
-          "Coordinate": {
-            "properties": {
-              "x": {
-                "default": 0.0,
-                "format": "double",
-                "type": "number"
-              },
-              "y": {
-                "default": 0.0,
-                "format": "double",
-                "type": "number"
-              }
-            },
-            "type": "object"
-          },
-          "PhotoAsset": {
-            "properties": {
-              "boundingBox": {
-                "anyOf": [
-                  {
-                    "$ref": "#/components/schemas/ConnectionsResponse/$defs/BoundingBox"
-                  },
-                  {
-                    "type": "null"
-                  }
-                ]
-              },
-              "caption": {
-                "type": [
-                  "string",
-                  "null"
-                ]
-              },
-              "cdnId": {
-                "type": [
-                  "string",
-                  "null"
-                ]
-              },
-              "contentId": {
-                "type": [
-                  "string",
-                  "null"
-                ]
-              },
-              "height": {
-                "format": "int32",
-                "type": [
-                  "integer",
-                  "null"
-                ]
-              },
-              "id": {
-                "type": [
-                  "string",
-                  "null"
-                ]
-              },
-              "location": {
-                "type": [
-                  "string",
-                  "null"
-                ]
-              },
-              "pHash": {
-                "type": [
-                  "string",
-                  "null"
-                ]
-              },
-              "promptId": {
-                "type": [
-                  "string",
-                  "null"
-                ]
-              },
-              "selfieVerified": {
-                "type": [
-                  "boolean",
-                  "null"
-                ]
-              },
-              "source": {
-                "type": [
-                  "string",
-                  "null"
-                ]
-              },
-              "sourceId": {
-                "type": [
-                  "string",
-                  "null"
-                ]
-              },
-              "url": {
-                "type": "string"
-              },
-              "videoUrl": {
-                "type": [
-                  "string",
-                  "null"
-                ]
-              },
-              "width": {
-                "format": "int32",
-                "type": [
-                  "integer",
-                  "null"
-                ]
-              }
-            },
-            "required": [
-              "url"
-            ],
-            "type": "object"
-          }
-        },
         "properties": {
           "connections": {
             "default": [],
             "items": {
-              "$ref": "#/components/schemas/ConnectionsResponse/$defs/ConnectionItem"
+              "$ref": "#/components/schemas/ConnectionItem"
             },
             "type": "array"
           },
@@ -1376,317 +388,25 @@
         "type": "object"
       },
       "ContentData": {
-        "$defs": {
-          "BoundingBox": {
-            "properties": {
-              "bottomRight": {
-                "$ref": "#/components/schemas/ContentData/$defs/Coordinate",
-                "default": {
-                  "x": 0.0,
-                  "y": 0.0
-                }
-              },
-              "topLeft": {
-                "$ref": "#/components/schemas/ContentData/$defs/Coordinate",
-                "default": {
-                  "x": 0.0,
-                  "y": 0.0
-                }
-              }
-            },
-            "type": "object"
-          },
-          "Coordinate": {
-            "properties": {
-              "x": {
-                "default": 0.0,
-                "format": "double",
-                "type": "number"
-              },
-              "y": {
-                "default": 0.0,
-                "format": "double",
-                "type": "number"
-              }
-            },
-            "type": "object"
-          },
-          "Feedback": {
-            "properties": {
-              "detail": {
-                "type": "string"
-              },
-              "evaluation": {
-                "type": "string"
-              },
-              "feedbackToken": {
-                "type": "string"
-              }
-            },
-            "required": [
-              "evaluation",
-              "detail",
-              "feedbackToken"
-            ],
-            "type": "object"
-          },
-          "PhotoAsset": {
-            "properties": {
-              "boundingBox": {
-                "anyOf": [
-                  {
-                    "$ref": "#/components/schemas/ContentData/$defs/BoundingBox"
-                  },
-                  {
-                    "type": "null"
-                  }
-                ]
-              },
-              "caption": {
-                "type": [
-                  "string",
-                  "null"
-                ]
-              },
-              "cdnId": {
-                "type": [
-                  "string",
-                  "null"
-                ]
-              },
-              "contentId": {
-                "type": [
-                  "string",
-                  "null"
-                ]
-              },
-              "height": {
-                "format": "int32",
-                "type": [
-                  "integer",
-                  "null"
-                ]
-              },
-              "id": {
-                "type": [
-                  "string",
-                  "null"
-                ]
-              },
-              "location": {
-                "type": [
-                  "string",
-                  "null"
-                ]
-              },
-              "pHash": {
-                "type": [
-                  "string",
-                  "null"
-                ]
-              },
-              "promptId": {
-                "type": [
-                  "string",
-                  "null"
-                ]
-              },
-              "selfieVerified": {
-                "type": [
-                  "boolean",
-                  "null"
-                ]
-              },
-              "source": {
-                "type": [
-                  "string",
-                  "null"
-                ]
-              },
-              "sourceId": {
-                "type": [
-                  "string",
-                  "null"
-                ]
-              },
-              "url": {
-                "type": "string"
-              },
-              "videoUrl": {
-                "type": [
-                  "string",
-                  "null"
-                ]
-              },
-              "width": {
-                "format": "int32",
-                "type": [
-                  "integer",
-                  "null"
-                ]
-              }
-            },
-            "required": [
-              "url"
-            ],
-            "type": "object"
-          },
-          "ProfileAnswer": {
-            "properties": {
-              "cdnId": {
-                "type": [
-                  "string",
-                  "null"
-                ]
-              },
-              "content": {
-                "type": [
-                  "string",
-                  "null"
-                ]
-              },
-              "contentId": {
-                "type": [
-                  "string",
-                  "null"
-                ]
-              },
-              "feedback": {
-                "anyOf": [
-                  {
-                    "$ref": "#/components/schemas/ContentData/$defs/Feedback"
-                  },
-                  {
-                    "type": "null"
-                  }
-                ]
-              },
-              "position": {
-                "format": "int32",
-                "type": [
-                  "integer",
-                  "null"
-                ]
-              },
-              "promptId": {
-                "type": [
-                  "string",
-                  "null"
-                ]
-              },
-              "questionId": {
-                "type": [
-                  "string",
-                  "null"
-                ]
-              },
-              "response": {
-                "type": [
-                  "string",
-                  "null"
-                ]
-              },
-              "transcription": {
-                "type": [
-                  "string",
-                  "null"
-                ]
-              },
-              "transcriptionMetadata": true,
-              "type": {
-                "type": [
-                  "string",
-                  "null"
-                ]
-              },
-              "url": {
-                "type": [
-                  "string",
-                  "null"
-                ]
-              },
-              "waveform": {
-                "type": [
-                  "string",
-                  "null"
-                ]
-              }
-            },
-            "type": "object"
-          },
-          "PromptPoll": {
-            "properties": {
-              "contentId": {
-                "type": "string"
-              },
-              "options": {
-                "items": {
-                  "type": "string"
-                },
-                "type": "array"
-              },
-              "questionId": {
-                "type": "string"
-              }
-            },
-            "required": [
-              "contentId",
-              "questionId",
-              "options"
-            ],
-            "type": "object"
-          },
-          "VideoPrompt": {
-            "properties": {
-              "boundingBox": {
-                "$ref": "#/components/schemas/ContentData/$defs/BoundingBox"
-              },
-              "cdnId": {
-                "type": "string"
-              },
-              "contentId": {
-                "type": "string"
-              },
-              "questionId": {
-                "type": "string"
-              },
-              "thumbnailUrl": {
-                "type": "string"
-              },
-              "videoUrl": {
-                "type": "string"
-              }
-            },
-            "required": [
-              "contentId",
-              "questionId",
-              "thumbnailUrl",
-              "videoUrl",
-              "cdnId",
-              "boundingBox"
-            ],
-            "type": "object"
-          }
-        },
         "properties": {
           "answers": {
             "default": [],
             "items": {
-              "$ref": "#/components/schemas/ContentData/$defs/ProfileAnswer"
+              "$ref": "#/components/schemas/ProfileAnswer"
             },
             "type": "array"
           },
           "photos": {
             "default": [],
             "items": {
-              "$ref": "#/components/schemas/ContentData/$defs/PhotoAsset"
+              "$ref": "#/components/schemas/PhotoAsset"
             },
             "type": "array"
           },
           "promptPoll": {
             "anyOf": [
               {
-                "$ref": "#/components/schemas/ContentData/$defs/PromptPoll"
+                "$ref": "#/components/schemas/PromptPoll"
               },
               {
                 "type": "null"
@@ -1696,7 +416,7 @@
           "videoPrompt": {
             "anyOf": [
               {
-                "$ref": "#/components/schemas/ContentData/$defs/VideoPrompt"
+                "$ref": "#/components/schemas/VideoPrompt"
               },
               {
                 "type": "null"
@@ -1705,6 +425,32 @@
           }
         },
         "title": "ContentData",
+        "type": "object"
+      },
+      "ContentType": {
+        "enum": [
+          "text",
+          "media",
+          "audio",
+          "video",
+          "voice",
+          "poll"
+        ],
+        "type": "string"
+      },
+      "Coordinate": {
+        "properties": {
+          "x": {
+            "default": 0.0,
+            "format": "double",
+            "type": "number"
+          },
+          "y": {
+            "default": 0.0,
+            "format": "double",
+            "type": "number"
+          }
+        },
         "type": "object"
       },
       "CreatePromptPollRequest": {
@@ -1739,200 +485,11 @@
         "type": "object"
       },
       "CreateRate": {
-        "$defs": {
-          "BoundingBox": {
-            "properties": {
-              "bottomRight": {
-                "$ref": "#/components/schemas/CreateRate/$defs/Coordinate",
-                "default": {
-                  "x": 0.0,
-                  "y": 0.0
-                }
-              },
-              "topLeft": {
-                "$ref": "#/components/schemas/CreateRate/$defs/Coordinate",
-                "default": {
-                  "x": 0.0,
-                  "y": 0.0
-                }
-              }
-            },
-            "type": "object"
-          },
-          "Coordinate": {
-            "properties": {
-              "x": {
-                "default": 0.0,
-                "format": "double",
-                "type": "number"
-              },
-              "y": {
-                "default": 0.0,
-                "format": "double",
-                "type": "number"
-              }
-            },
-            "type": "object"
-          },
-          "CreateRateContent": {
-            "properties": {
-              "comment": {
-                "type": [
-                  "string",
-                  "null"
-                ]
-              },
-              "photo": {
-                "anyOf": [
-                  {
-                    "$ref": "#/components/schemas/CreateRate/$defs/PhotoAsset"
-                  },
-                  {
-                    "type": "null"
-                  }
-                ]
-              },
-              "prompt": {
-                "anyOf": [
-                  {
-                    "$ref": "#/components/schemas/CreateRate/$defs/CreateRateContentPrompt"
-                  },
-                  {
-                    "type": "null"
-                  }
-                ]
-              }
-            },
-            "type": "object"
-          },
-          "CreateRateContentPrompt": {
-            "properties": {
-              "answer": {
-                "type": "string"
-              },
-              "contentId": {
-                "type": [
-                  "string",
-                  "null"
-                ]
-              },
-              "question": {
-                "type": "string"
-              }
-            },
-            "required": [
-              "answer",
-              "question"
-            ],
-            "type": "object"
-          },
-          "PhotoAsset": {
-            "properties": {
-              "boundingBox": {
-                "anyOf": [
-                  {
-                    "$ref": "#/components/schemas/CreateRate/$defs/BoundingBox"
-                  },
-                  {
-                    "type": "null"
-                  }
-                ]
-              },
-              "caption": {
-                "type": [
-                  "string",
-                  "null"
-                ]
-              },
-              "cdnId": {
-                "type": [
-                  "string",
-                  "null"
-                ]
-              },
-              "contentId": {
-                "type": [
-                  "string",
-                  "null"
-                ]
-              },
-              "height": {
-                "format": "int32",
-                "type": [
-                  "integer",
-                  "null"
-                ]
-              },
-              "id": {
-                "type": [
-                  "string",
-                  "null"
-                ]
-              },
-              "location": {
-                "type": [
-                  "string",
-                  "null"
-                ]
-              },
-              "pHash": {
-                "type": [
-                  "string",
-                  "null"
-                ]
-              },
-              "promptId": {
-                "type": [
-                  "string",
-                  "null"
-                ]
-              },
-              "selfieVerified": {
-                "type": [
-                  "boolean",
-                  "null"
-                ]
-              },
-              "source": {
-                "type": [
-                  "string",
-                  "null"
-                ]
-              },
-              "sourceId": {
-                "type": [
-                  "string",
-                  "null"
-                ]
-              },
-              "url": {
-                "type": "string"
-              },
-              "videoUrl": {
-                "type": [
-                  "string",
-                  "null"
-                ]
-              },
-              "width": {
-                "format": "int32",
-                "type": [
-                  "integer",
-                  "null"
-                ]
-              }
-            },
-            "required": [
-              "url"
-            ],
-            "type": "object"
-          }
-        },
         "properties": {
           "content": {
             "anyOf": [
               {
-                "$ref": "#/components/schemas/CreateRate/$defs/CreateRateContent"
+                "$ref": "#/components/schemas/CreateRateContent"
               },
               {
                 "type": "null"
@@ -1992,164 +549,6 @@
         "type": "object"
       },
       "CreateRateContent": {
-        "$defs": {
-          "BoundingBox": {
-            "properties": {
-              "bottomRight": {
-                "$ref": "#/components/schemas/CreateRateContent/$defs/Coordinate",
-                "default": {
-                  "x": 0.0,
-                  "y": 0.0
-                }
-              },
-              "topLeft": {
-                "$ref": "#/components/schemas/CreateRateContent/$defs/Coordinate",
-                "default": {
-                  "x": 0.0,
-                  "y": 0.0
-                }
-              }
-            },
-            "type": "object"
-          },
-          "Coordinate": {
-            "properties": {
-              "x": {
-                "default": 0.0,
-                "format": "double",
-                "type": "number"
-              },
-              "y": {
-                "default": 0.0,
-                "format": "double",
-                "type": "number"
-              }
-            },
-            "type": "object"
-          },
-          "CreateRateContentPrompt": {
-            "properties": {
-              "answer": {
-                "type": "string"
-              },
-              "contentId": {
-                "type": [
-                  "string",
-                  "null"
-                ]
-              },
-              "question": {
-                "type": "string"
-              }
-            },
-            "required": [
-              "answer",
-              "question"
-            ],
-            "type": "object"
-          },
-          "PhotoAsset": {
-            "properties": {
-              "boundingBox": {
-                "anyOf": [
-                  {
-                    "$ref": "#/components/schemas/CreateRateContent/$defs/BoundingBox"
-                  },
-                  {
-                    "type": "null"
-                  }
-                ]
-              },
-              "caption": {
-                "type": [
-                  "string",
-                  "null"
-                ]
-              },
-              "cdnId": {
-                "type": [
-                  "string",
-                  "null"
-                ]
-              },
-              "contentId": {
-                "type": [
-                  "string",
-                  "null"
-                ]
-              },
-              "height": {
-                "format": "int32",
-                "type": [
-                  "integer",
-                  "null"
-                ]
-              },
-              "id": {
-                "type": [
-                  "string",
-                  "null"
-                ]
-              },
-              "location": {
-                "type": [
-                  "string",
-                  "null"
-                ]
-              },
-              "pHash": {
-                "type": [
-                  "string",
-                  "null"
-                ]
-              },
-              "promptId": {
-                "type": [
-                  "string",
-                  "null"
-                ]
-              },
-              "selfieVerified": {
-                "type": [
-                  "boolean",
-                  "null"
-                ]
-              },
-              "source": {
-                "type": [
-                  "string",
-                  "null"
-                ]
-              },
-              "sourceId": {
-                "type": [
-                  "string",
-                  "null"
-                ]
-              },
-              "url": {
-                "type": "string"
-              },
-              "videoUrl": {
-                "type": [
-                  "string",
-                  "null"
-                ]
-              },
-              "width": {
-                "format": "int32",
-                "type": [
-                  "integer",
-                  "null"
-                ]
-              }
-            },
-            "required": [
-              "url"
-            ],
-            "type": "object"
-          }
-        },
         "properties": {
           "comment": {
             "type": [
@@ -2160,7 +559,7 @@
           "photo": {
             "anyOf": [
               {
-                "$ref": "#/components/schemas/CreateRateContent/$defs/PhotoAsset"
+                "$ref": "#/components/schemas/PhotoAsset"
               },
               {
                 "type": "null"
@@ -2170,7 +569,7 @@
           "prompt": {
             "anyOf": [
               {
-                "$ref": "#/components/schemas/CreateRateContent/$defs/CreateRateContentPrompt"
+                "$ref": "#/components/schemas/CreateRateContentPrompt"
               },
               {
                 "type": "null"
@@ -2204,45 +603,9 @@
         "type": "object"
       },
       "CreateVideoPromptRequest": {
-        "$defs": {
-          "BoundingBox": {
-            "properties": {
-              "bottomRight": {
-                "$ref": "#/components/schemas/CreateVideoPromptRequest/$defs/Coordinate",
-                "default": {
-                  "x": 0.0,
-                  "y": 0.0
-                }
-              },
-              "topLeft": {
-                "$ref": "#/components/schemas/CreateVideoPromptRequest/$defs/Coordinate",
-                "default": {
-                  "x": 0.0,
-                  "y": 0.0
-                }
-              }
-            },
-            "type": "object"
-          },
-          "Coordinate": {
-            "properties": {
-              "x": {
-                "default": 0.0,
-                "format": "double",
-                "type": "number"
-              },
-              "y": {
-                "default": 0.0,
-                "format": "double",
-                "type": "number"
-              }
-            },
-            "type": "object"
-          }
-        },
         "properties": {
           "boundingBox": {
-            "$ref": "#/components/schemas/CreateVideoPromptRequest/$defs/BoundingBox"
+            "$ref": "#/components/schemas/BoundingBox"
           },
           "cdnId": {
             "type": "string"
@@ -2288,32 +651,46 @@
         "title": "CreateVideoPromptResponse",
         "type": "object"
       },
-      "Dealbreakers": {
-        "$defs": {
-          "GenderedDealbreaker": {
-            "properties": {
-              "0": {
-                "type": [
-                  "boolean",
-                  "null"
-                ]
-              },
-              "1": {
-                "type": [
-                  "boolean",
-                  "null"
-                ]
-              },
-              "3": {
-                "type": [
-                  "boolean",
-                  "null"
-                ]
-              }
-            },
-            "type": "object"
+      "DatingIntention": {
+        "properties": {
+          "value": {
+            "$ref": "#/components/schemas/DatingIntentionProfile"
+          },
+          "visible": {
+            "type": "boolean"
           }
         },
+        "required": [
+          "value",
+          "visible"
+        ],
+        "type": "object"
+      },
+      "DatingIntentionPreference": {
+        "enum": [
+          "OpenToAll",
+          "LifePartner",
+          "LongTermRelationship",
+          "LongTermOpenToShort",
+          "ShortTermOpenToLong",
+          "ShortTermRelationship",
+          "FiguringOutTheirDatingGoals"
+        ],
+        "type": "string"
+      },
+      "DatingIntentionProfile": {
+        "enum": [
+          "PreferNotToSay",
+          "LifePartner",
+          "LongTermRelationship",
+          "LongTermOpenToShort",
+          "ShortTermOpenToLong",
+          "ShortTermRelationship",
+          "FiguringOutTheirDatingGoals"
+        ],
+        "type": "string"
+      },
+      "Dealbreakers": {
         "properties": {
           "children": {
             "type": "boolean"
@@ -2337,10 +714,10 @@
             "type": "boolean"
           },
           "genderedAge": {
-            "$ref": "#/components/schemas/Dealbreakers/$defs/GenderedDealbreaker"
+            "$ref": "#/components/schemas/GenderedDealbreaker"
           },
           "genderedHeight": {
-            "$ref": "#/components/schemas/Dealbreakers/$defs/GenderedDealbreaker"
+            "$ref": "#/components/schemas/GenderedDealbreaker"
           },
           "marijuana": {
             "type": "boolean"
@@ -2381,6 +758,114 @@
         "title": "Dealbreakers",
         "type": "object"
       },
+      "DrinkingStatus": {
+        "properties": {
+          "value": {
+            "$ref": "#/components/schemas/DrinkingStatusProfile"
+          },
+          "visible": {
+            "type": "boolean"
+          }
+        },
+        "required": [
+          "value",
+          "visible"
+        ],
+        "type": "object"
+      },
+      "DrinkingStatusPreference": {
+        "enum": [
+          "OpenToAll",
+          "No",
+          "Yes",
+          "Sometimes"
+        ],
+        "type": "string"
+      },
+      "DrinkingStatusProfile": {
+        "enum": [
+          "PreferNotToSay",
+          "No",
+          "Yes",
+          "Sometimes"
+        ],
+        "type": "string"
+      },
+      "DrugStatus": {
+        "properties": {
+          "value": {
+            "$ref": "#/components/schemas/DrugStatusProfile"
+          },
+          "visible": {
+            "type": "boolean"
+          }
+        },
+        "required": [
+          "value",
+          "visible"
+        ],
+        "type": "object"
+      },
+      "DrugStatusPreference": {
+        "enum": [
+          "OpenToAll",
+          "No",
+          "Yes",
+          "Sometimes"
+        ],
+        "type": "string"
+      },
+      "DrugStatusProfile": {
+        "enum": [
+          "PreferNotToSay",
+          "No",
+          "Yes",
+          "Sometimes"
+        ],
+        "type": "string"
+      },
+      "EducationAttainedPreference": {
+        "enum": [
+          "OpenToAll",
+          "HighSchool",
+          "TradeSchool",
+          "InCollege",
+          "Undergraduate",
+          "InGradSchool",
+          "Graduate"
+        ],
+        "type": "string"
+      },
+      "EducationAttainedProfile": {
+        "enum": [
+          "PreferNotToSay",
+          "HighSchool",
+          "TradeSchool",
+          "InCollege",
+          "Undergraduate",
+          "InGradSchool",
+          "Graduate"
+        ],
+        "type": "string"
+      },
+      "Educations": {
+        "properties": {
+          "value": {
+            "items": {
+              "type": "string"
+            },
+            "type": "array"
+          },
+          "visible": {
+            "type": "boolean"
+          }
+        },
+        "required": [
+          "value",
+          "visible"
+        ],
+        "type": "object"
+      },
       "EmailCodeRequest": {
         "additionalProperties": true,
         "properties": {
@@ -2413,6 +898,54 @@
         },
         "type": "object"
       },
+      "Ethnicities": {
+        "properties": {
+          "value": {
+            "items": {
+              "$ref": "#/components/schemas/EthnicityProfile"
+            },
+            "type": "array"
+          },
+          "visible": {
+            "type": "boolean"
+          }
+        },
+        "required": [
+          "value",
+          "visible"
+        ],
+        "type": "object"
+      },
+      "EthnicityPreference": {
+        "enum": [
+          "OpenToAll",
+          "AmericanIndian",
+          "BlackAfrican",
+          "EastAsian",
+          "Hispanic",
+          "MiddleEastern",
+          "PacificIslander",
+          "SouthAsian",
+          "White",
+          "Other"
+        ],
+        "type": "string"
+      },
+      "EthnicityProfile": {
+        "enum": [
+          "PreferNotToSay",
+          "AmericanIndian",
+          "BlackAfrican",
+          "EastAsian",
+          "Hispanic",
+          "MiddleEastern",
+          "PacificIslander",
+          "SouthAsian",
+          "White",
+          "Other"
+        ],
+        "type": "string"
+      },
       "ExportChatInput": {
         "properties": {
           "channelUrl": {
@@ -2443,34 +976,13 @@
         "type": "object"
       },
       "ExportChatResult": {
-        "$defs": {
-          "ExportedMediaFile": {
-            "properties": {
-              "fileName": {
-                "type": "string"
-              },
-              "filePath": {
-                "type": "string"
-              },
-              "messageId": {
-                "type": "string"
-              }
-            },
-            "required": [
-              "messageId",
-              "fileName",
-              "filePath"
-            ],
-            "type": "object"
-          }
-        },
         "properties": {
           "folderPath": {
             "type": "string"
           },
           "mediaFiles": {
             "items": {
-              "$ref": "#/components/schemas/ExportChatResult/$defs/ExportedMediaFile"
+              "$ref": "#/components/schemas/ExportedMediaFile"
             },
             "type": "array"
           },
@@ -2542,6 +1054,22 @@
         "title": "ExportedMediaFile",
         "type": "object"
       },
+      "FamilyPlans": {
+        "properties": {
+          "value": {
+            "format": "int32",
+            "type": "integer"
+          },
+          "visible": {
+            "type": "boolean"
+          }
+        },
+        "required": [
+          "value",
+          "visible"
+        ],
+        "type": "object"
+      },
       "Feedback": {
         "properties": {
           "detail": {
@@ -2561,6 +1089,38 @@
         ],
         "title": "Feedback",
         "type": "object"
+      },
+      "GenderEnum": {
+        "enum": [
+          "Man",
+          "Woman",
+          "NonBinary"
+        ],
+        "type": "string"
+      },
+      "GenderIdentityId": {
+        "properties": {
+          "value": {
+            "format": "int32",
+            "type": "integer"
+          },
+          "visible": {
+            "type": "boolean"
+          }
+        },
+        "required": [
+          "value",
+          "visible"
+        ],
+        "type": "object"
+      },
+      "GenderPreferences": {
+        "enum": [
+          "Men",
+          "Women",
+          "Everyone"
+        ],
+        "type": "string"
       },
       "GenderedDealbreaker": {
         "properties": {
@@ -2587,32 +1147,11 @@
         "type": "object"
       },
       "GenderedRange": {
-        "$defs": {
-          "RangeDetails": {
-            "properties": {
-              "max": {
-                "format": "int32",
-                "type": [
-                  "integer",
-                  "null"
-                ]
-              },
-              "min": {
-                "format": "int32",
-                "type": [
-                  "integer",
-                  "null"
-                ]
-              }
-            },
-            "type": "object"
-          }
-        },
         "properties": {
           "0": {
             "anyOf": [
               {
-                "$ref": "#/components/schemas/GenderedRange/$defs/RangeDetails"
+                "$ref": "#/components/schemas/RangeDetails"
               },
               {
                 "type": "null"
@@ -2622,7 +1161,7 @@
           "1": {
             "anyOf": [
               {
-                "$ref": "#/components/schemas/GenderedRange/$defs/RangeDetails"
+                "$ref": "#/components/schemas/RangeDetails"
               },
               {
                 "type": "null"
@@ -2632,7 +1171,7 @@
           "3": {
             "anyOf": [
               {
-                "$ref": "#/components/schemas/GenderedRange/$defs/RangeDetails"
+                "$ref": "#/components/schemas/RangeDetails"
               },
               {
                 "type": "null"
@@ -2664,6 +1203,21 @@
         "title": "HingeAuthToken",
         "type": "object"
       },
+      "Hometown": {
+        "properties": {
+          "value": {
+            "type": "string"
+          },
+          "visible": {
+            "type": "boolean"
+          }
+        },
+        "required": [
+          "value",
+          "visible"
+        ],
+        "type": "object"
+      },
       "InstallRequest": {
         "additionalProperties": true,
         "properties": {
@@ -2673,259 +1227,41 @@
         },
         "type": "object"
       },
-      "LikeItemV2": {
-        "$defs": {
-          "BoundingBox": {
-            "properties": {
-              "bottomRight": {
-                "$ref": "#/components/schemas/LikeItemV2/$defs/Coordinate",
-                "default": {
-                  "x": 0.0,
-                  "y": 0.0
-                }
-              },
-              "topLeft": {
-                "$ref": "#/components/schemas/LikeItemV2/$defs/Coordinate",
-                "default": {
-                  "x": 0.0,
-                  "y": 0.0
-                }
-              }
-            },
-            "type": "object"
+      "JobTitle": {
+        "properties": {
+          "value": {
+            "type": "string"
           },
-          "Coordinate": {
-            "properties": {
-              "x": {
-                "default": 0.0,
-                "format": "double",
-                "type": "number"
-              },
-              "y": {
-                "default": 0.0,
-                "format": "double",
-                "type": "number"
-              }
-            },
-            "type": "object"
-          },
-          "CreateRateContentPrompt": {
-            "properties": {
-              "answer": {
-                "type": "string"
-              },
-              "contentId": {
-                "type": [
-                  "string",
-                  "null"
-                ]
-              },
-              "question": {
-                "type": "string"
-              }
-            },
-            "required": [
-              "answer",
-              "question"
-            ],
-            "type": "object"
-          },
-          "LikePromptPoll": {
-            "properties": {
-              "contentId": {
-                "type": [
-                  "string",
-                  "null"
-                ]
-              },
-              "options": {
-                "items": {
-                  "type": "string"
-                },
-                "type": "array"
-              },
-              "questionId": {
-                "type": "string"
-              },
-              "selectedOption": {
-                "type": [
-                  "string",
-                  "null"
-                ]
-              },
-              "selectedOptionIndex": {
-                "format": "int32",
-                "type": [
-                  "integer",
-                  "null"
-                ]
-              }
-            },
-            "required": [
-              "options",
-              "questionId"
-            ],
-            "type": "object"
-          },
-          "LikeRating": {
-            "properties": {
-              "content": {
-                "default": [],
-                "items": {
-                  "$ref": "#/components/schemas/LikeItemV2/$defs/LikeRatingContentItem"
-                },
-                "type": "array"
-              }
-            },
-            "type": "object"
-          },
-          "LikeRatingContentItem": {
-            "properties": {
-              "comment": {
-                "default": null,
-                "type": [
-                  "string",
-                  "null"
-                ]
-              },
-              "photo": {
-                "anyOf": [
-                  {
-                    "$ref": "#/components/schemas/LikeItemV2/$defs/PhotoAsset"
-                  },
-                  {
-                    "type": "null"
-                  }
-                ],
-                "default": null
-              },
-              "prompt": {
-                "anyOf": [
-                  {
-                    "$ref": "#/components/schemas/LikeItemV2/$defs/CreateRateContentPrompt"
-                  },
-                  {
-                    "type": "null"
-                  }
-                ],
-                "default": null
-              },
-              "promptPoll": {
-                "anyOf": [
-                  {
-                    "$ref": "#/components/schemas/LikeItemV2/$defs/LikePromptPoll"
-                  },
-                  {
-                    "type": "null"
-                  }
-                ],
-                "default": null
-              }
-            },
-            "type": "object"
-          },
-          "PhotoAsset": {
-            "properties": {
-              "boundingBox": {
-                "anyOf": [
-                  {
-                    "$ref": "#/components/schemas/LikeItemV2/$defs/BoundingBox"
-                  },
-                  {
-                    "type": "null"
-                  }
-                ]
-              },
-              "caption": {
-                "type": [
-                  "string",
-                  "null"
-                ]
-              },
-              "cdnId": {
-                "type": [
-                  "string",
-                  "null"
-                ]
-              },
-              "contentId": {
-                "type": [
-                  "string",
-                  "null"
-                ]
-              },
-              "height": {
-                "format": "int32",
-                "type": [
-                  "integer",
-                  "null"
-                ]
-              },
-              "id": {
-                "type": [
-                  "string",
-                  "null"
-                ]
-              },
-              "location": {
-                "type": [
-                  "string",
-                  "null"
-                ]
-              },
-              "pHash": {
-                "type": [
-                  "string",
-                  "null"
-                ]
-              },
-              "promptId": {
-                "type": [
-                  "string",
-                  "null"
-                ]
-              },
-              "selfieVerified": {
-                "type": [
-                  "boolean",
-                  "null"
-                ]
-              },
-              "source": {
-                "type": [
-                  "string",
-                  "null"
-                ]
-              },
-              "sourceId": {
-                "type": [
-                  "string",
-                  "null"
-                ]
-              },
-              "url": {
-                "type": "string"
-              },
-              "videoUrl": {
-                "type": [
-                  "string",
-                  "null"
-                ]
-              },
-              "width": {
-                "format": "int32",
-                "type": [
-                  "integer",
-                  "null"
-                ]
-              }
-            },
-            "required": [
-              "url"
-            ],
-            "type": "object"
+          "visible": {
+            "type": "boolean"
           }
         },
+        "required": [
+          "value",
+          "visible"
+        ],
+        "type": "object"
+      },
+      "LanguagesSpoken": {
+        "properties": {
+          "value": {
+            "items": {
+              "format": "int32",
+              "type": "integer"
+            },
+            "type": "array"
+          },
+          "visible": {
+            "type": "boolean"
+          }
+        },
+        "required": [
+          "value",
+          "visible"
+        ],
+        "type": "object"
+      },
+      "LikeItemV2": {
         "properties": {
           "created": {
             "type": "string"
@@ -2937,7 +1273,7 @@
             "type": "string"
           },
           "rating": {
-            "$ref": "#/components/schemas/LikeItemV2/$defs/LikeRating"
+            "$ref": "#/components/schemas/LikeRating"
           },
           "source": {
             "type": "string"
@@ -3017,251 +1353,11 @@
         "type": "object"
       },
       "LikeRating": {
-        "$defs": {
-          "BoundingBox": {
-            "properties": {
-              "bottomRight": {
-                "$ref": "#/components/schemas/LikeRating/$defs/Coordinate",
-                "default": {
-                  "x": 0.0,
-                  "y": 0.0
-                }
-              },
-              "topLeft": {
-                "$ref": "#/components/schemas/LikeRating/$defs/Coordinate",
-                "default": {
-                  "x": 0.0,
-                  "y": 0.0
-                }
-              }
-            },
-            "type": "object"
-          },
-          "Coordinate": {
-            "properties": {
-              "x": {
-                "default": 0.0,
-                "format": "double",
-                "type": "number"
-              },
-              "y": {
-                "default": 0.0,
-                "format": "double",
-                "type": "number"
-              }
-            },
-            "type": "object"
-          },
-          "CreateRateContentPrompt": {
-            "properties": {
-              "answer": {
-                "type": "string"
-              },
-              "contentId": {
-                "type": [
-                  "string",
-                  "null"
-                ]
-              },
-              "question": {
-                "type": "string"
-              }
-            },
-            "required": [
-              "answer",
-              "question"
-            ],
-            "type": "object"
-          },
-          "LikePromptPoll": {
-            "properties": {
-              "contentId": {
-                "type": [
-                  "string",
-                  "null"
-                ]
-              },
-              "options": {
-                "items": {
-                  "type": "string"
-                },
-                "type": "array"
-              },
-              "questionId": {
-                "type": "string"
-              },
-              "selectedOption": {
-                "type": [
-                  "string",
-                  "null"
-                ]
-              },
-              "selectedOptionIndex": {
-                "format": "int32",
-                "type": [
-                  "integer",
-                  "null"
-                ]
-              }
-            },
-            "required": [
-              "options",
-              "questionId"
-            ],
-            "type": "object"
-          },
-          "LikeRatingContentItem": {
-            "properties": {
-              "comment": {
-                "default": null,
-                "type": [
-                  "string",
-                  "null"
-                ]
-              },
-              "photo": {
-                "anyOf": [
-                  {
-                    "$ref": "#/components/schemas/LikeRating/$defs/PhotoAsset"
-                  },
-                  {
-                    "type": "null"
-                  }
-                ],
-                "default": null
-              },
-              "prompt": {
-                "anyOf": [
-                  {
-                    "$ref": "#/components/schemas/LikeRating/$defs/CreateRateContentPrompt"
-                  },
-                  {
-                    "type": "null"
-                  }
-                ],
-                "default": null
-              },
-              "promptPoll": {
-                "anyOf": [
-                  {
-                    "$ref": "#/components/schemas/LikeRating/$defs/LikePromptPoll"
-                  },
-                  {
-                    "type": "null"
-                  }
-                ],
-                "default": null
-              }
-            },
-            "type": "object"
-          },
-          "PhotoAsset": {
-            "properties": {
-              "boundingBox": {
-                "anyOf": [
-                  {
-                    "$ref": "#/components/schemas/LikeRating/$defs/BoundingBox"
-                  },
-                  {
-                    "type": "null"
-                  }
-                ]
-              },
-              "caption": {
-                "type": [
-                  "string",
-                  "null"
-                ]
-              },
-              "cdnId": {
-                "type": [
-                  "string",
-                  "null"
-                ]
-              },
-              "contentId": {
-                "type": [
-                  "string",
-                  "null"
-                ]
-              },
-              "height": {
-                "format": "int32",
-                "type": [
-                  "integer",
-                  "null"
-                ]
-              },
-              "id": {
-                "type": [
-                  "string",
-                  "null"
-                ]
-              },
-              "location": {
-                "type": [
-                  "string",
-                  "null"
-                ]
-              },
-              "pHash": {
-                "type": [
-                  "string",
-                  "null"
-                ]
-              },
-              "promptId": {
-                "type": [
-                  "string",
-                  "null"
-                ]
-              },
-              "selfieVerified": {
-                "type": [
-                  "boolean",
-                  "null"
-                ]
-              },
-              "source": {
-                "type": [
-                  "string",
-                  "null"
-                ]
-              },
-              "sourceId": {
-                "type": [
-                  "string",
-                  "null"
-                ]
-              },
-              "url": {
-                "type": "string"
-              },
-              "videoUrl": {
-                "type": [
-                  "string",
-                  "null"
-                ]
-              },
-              "width": {
-                "format": "int32",
-                "type": [
-                  "integer",
-                  "null"
-                ]
-              }
-            },
-            "required": [
-              "url"
-            ],
-            "type": "object"
-          }
-        },
         "properties": {
           "content": {
             "default": [],
             "items": {
-              "$ref": "#/components/schemas/LikeRating/$defs/LikeRatingContentItem"
+              "$ref": "#/components/schemas/LikeRatingContentItem"
             },
             "type": "array"
           }
@@ -3270,201 +1366,6 @@
         "type": "object"
       },
       "LikeRatingContentItem": {
-        "$defs": {
-          "BoundingBox": {
-            "properties": {
-              "bottomRight": {
-                "$ref": "#/components/schemas/LikeRatingContentItem/$defs/Coordinate",
-                "default": {
-                  "x": 0.0,
-                  "y": 0.0
-                }
-              },
-              "topLeft": {
-                "$ref": "#/components/schemas/LikeRatingContentItem/$defs/Coordinate",
-                "default": {
-                  "x": 0.0,
-                  "y": 0.0
-                }
-              }
-            },
-            "type": "object"
-          },
-          "Coordinate": {
-            "properties": {
-              "x": {
-                "default": 0.0,
-                "format": "double",
-                "type": "number"
-              },
-              "y": {
-                "default": 0.0,
-                "format": "double",
-                "type": "number"
-              }
-            },
-            "type": "object"
-          },
-          "CreateRateContentPrompt": {
-            "properties": {
-              "answer": {
-                "type": "string"
-              },
-              "contentId": {
-                "type": [
-                  "string",
-                  "null"
-                ]
-              },
-              "question": {
-                "type": "string"
-              }
-            },
-            "required": [
-              "answer",
-              "question"
-            ],
-            "type": "object"
-          },
-          "LikePromptPoll": {
-            "properties": {
-              "contentId": {
-                "type": [
-                  "string",
-                  "null"
-                ]
-              },
-              "options": {
-                "items": {
-                  "type": "string"
-                },
-                "type": "array"
-              },
-              "questionId": {
-                "type": "string"
-              },
-              "selectedOption": {
-                "type": [
-                  "string",
-                  "null"
-                ]
-              },
-              "selectedOptionIndex": {
-                "format": "int32",
-                "type": [
-                  "integer",
-                  "null"
-                ]
-              }
-            },
-            "required": [
-              "options",
-              "questionId"
-            ],
-            "type": "object"
-          },
-          "PhotoAsset": {
-            "properties": {
-              "boundingBox": {
-                "anyOf": [
-                  {
-                    "$ref": "#/components/schemas/LikeRatingContentItem/$defs/BoundingBox"
-                  },
-                  {
-                    "type": "null"
-                  }
-                ]
-              },
-              "caption": {
-                "type": [
-                  "string",
-                  "null"
-                ]
-              },
-              "cdnId": {
-                "type": [
-                  "string",
-                  "null"
-                ]
-              },
-              "contentId": {
-                "type": [
-                  "string",
-                  "null"
-                ]
-              },
-              "height": {
-                "format": "int32",
-                "type": [
-                  "integer",
-                  "null"
-                ]
-              },
-              "id": {
-                "type": [
-                  "string",
-                  "null"
-                ]
-              },
-              "location": {
-                "type": [
-                  "string",
-                  "null"
-                ]
-              },
-              "pHash": {
-                "type": [
-                  "string",
-                  "null"
-                ]
-              },
-              "promptId": {
-                "type": [
-                  "string",
-                  "null"
-                ]
-              },
-              "selfieVerified": {
-                "type": [
-                  "boolean",
-                  "null"
-                ]
-              },
-              "source": {
-                "type": [
-                  "string",
-                  "null"
-                ]
-              },
-              "sourceId": {
-                "type": [
-                  "string",
-                  "null"
-                ]
-              },
-              "url": {
-                "type": "string"
-              },
-              "videoUrl": {
-                "type": [
-                  "string",
-                  "null"
-                ]
-              },
-              "width": {
-                "format": "int32",
-                "type": [
-                  "integer",
-                  "null"
-                ]
-              }
-            },
-            "required": [
-              "url"
-            ],
-            "type": "object"
-          }
-        },
         "properties": {
           "comment": {
             "default": null,
@@ -3476,7 +1377,7 @@
           "photo": {
             "anyOf": [
               {
-                "$ref": "#/components/schemas/LikeRatingContentItem/$defs/PhotoAsset"
+                "$ref": "#/components/schemas/PhotoAsset"
               },
               {
                 "type": "null"
@@ -3487,7 +1388,7 @@
           "prompt": {
             "anyOf": [
               {
-                "$ref": "#/components/schemas/LikeRatingContentItem/$defs/CreateRateContentPrompt"
+                "$ref": "#/components/schemas/CreateRateContentPrompt"
               },
               {
                 "type": "null"
@@ -3498,7 +1399,7 @@
           "promptPoll": {
             "anyOf": [
               {
-                "$ref": "#/components/schemas/LikeRatingContentItem/$defs/LikePromptPoll"
+                "$ref": "#/components/schemas/LikePromptPoll"
               },
               {
                 "type": "null"
@@ -3511,31 +1412,9 @@
         "type": "object"
       },
       "LikeResponse": {
-        "$defs": {
-          "LikeLimit": {
-            "properties": {
-              "likes": {
-                "format": "int32",
-                "type": "integer"
-              },
-              "superlikes": {
-                "default": null,
-                "format": "int32",
-                "type": [
-                  "integer",
-                  "null"
-                ]
-              }
-            },
-            "required": [
-              "likes"
-            ],
-            "type": "object"
-          }
-        },
         "properties": {
           "limit": {
-            "$ref": "#/components/schemas/LikeResponse/$defs/LikeLimit"
+            "$ref": "#/components/schemas/LikeLimit"
           }
         },
         "required": [
@@ -3561,333 +1440,6 @@
         "type": "object"
       },
       "LikesV2Response": {
-        "$defs": {
-          "BoundingBox": {
-            "properties": {
-              "bottomRight": {
-                "$ref": "#/components/schemas/LikesV2Response/$defs/Coordinate",
-                "default": {
-                  "x": 0.0,
-                  "y": 0.0
-                }
-              },
-              "topLeft": {
-                "$ref": "#/components/schemas/LikesV2Response/$defs/Coordinate",
-                "default": {
-                  "x": 0.0,
-                  "y": 0.0
-                }
-              }
-            },
-            "type": "object"
-          },
-          "Coordinate": {
-            "properties": {
-              "x": {
-                "default": 0.0,
-                "format": "double",
-                "type": "number"
-              },
-              "y": {
-                "default": 0.0,
-                "format": "double",
-                "type": "number"
-              }
-            },
-            "type": "object"
-          },
-          "CreateRateContentPrompt": {
-            "properties": {
-              "answer": {
-                "type": "string"
-              },
-              "contentId": {
-                "type": [
-                  "string",
-                  "null"
-                ]
-              },
-              "question": {
-                "type": "string"
-              }
-            },
-            "required": [
-              "answer",
-              "question"
-            ],
-            "type": "object"
-          },
-          "LikeItemV2": {
-            "properties": {
-              "created": {
-                "type": "string"
-              },
-              "initiatedWith": {
-                "type": "string"
-              },
-              "playerId": {
-                "type": "string"
-              },
-              "rating": {
-                "$ref": "#/components/schemas/LikesV2Response/$defs/LikeRating"
-              },
-              "source": {
-                "type": "string"
-              },
-              "subjectId": {
-                "type": "string"
-              }
-            },
-            "required": [
-              "playerId",
-              "subjectId",
-              "created",
-              "source",
-              "initiatedWith",
-              "rating"
-            ],
-            "type": "object"
-          },
-          "LikePromptPoll": {
-            "properties": {
-              "contentId": {
-                "type": [
-                  "string",
-                  "null"
-                ]
-              },
-              "options": {
-                "items": {
-                  "type": "string"
-                },
-                "type": "array"
-              },
-              "questionId": {
-                "type": "string"
-              },
-              "selectedOption": {
-                "type": [
-                  "string",
-                  "null"
-                ]
-              },
-              "selectedOptionIndex": {
-                "format": "int32",
-                "type": [
-                  "integer",
-                  "null"
-                ]
-              }
-            },
-            "required": [
-              "options",
-              "questionId"
-            ],
-            "type": "object"
-          },
-          "LikeRating": {
-            "properties": {
-              "content": {
-                "default": [],
-                "items": {
-                  "$ref": "#/components/schemas/LikesV2Response/$defs/LikeRatingContentItem"
-                },
-                "type": "array"
-              }
-            },
-            "type": "object"
-          },
-          "LikeRatingContentItem": {
-            "properties": {
-              "comment": {
-                "default": null,
-                "type": [
-                  "string",
-                  "null"
-                ]
-              },
-              "photo": {
-                "anyOf": [
-                  {
-                    "$ref": "#/components/schemas/LikesV2Response/$defs/PhotoAsset"
-                  },
-                  {
-                    "type": "null"
-                  }
-                ],
-                "default": null
-              },
-              "prompt": {
-                "anyOf": [
-                  {
-                    "$ref": "#/components/schemas/LikesV2Response/$defs/CreateRateContentPrompt"
-                  },
-                  {
-                    "type": "null"
-                  }
-                ],
-                "default": null
-              },
-              "promptPoll": {
-                "anyOf": [
-                  {
-                    "$ref": "#/components/schemas/LikesV2Response/$defs/LikePromptPoll"
-                  },
-                  {
-                    "type": "null"
-                  }
-                ],
-                "default": null
-              }
-            },
-            "type": "object"
-          },
-          "LikeSortV2": {
-            "properties": {
-              "id": {
-                "type": "string"
-              },
-              "title": {
-                "type": "string"
-              }
-            },
-            "required": [
-              "id",
-              "title"
-            ],
-            "type": "object"
-          },
-          "PhotoAsset": {
-            "properties": {
-              "boundingBox": {
-                "anyOf": [
-                  {
-                    "$ref": "#/components/schemas/LikesV2Response/$defs/BoundingBox"
-                  },
-                  {
-                    "type": "null"
-                  }
-                ]
-              },
-              "caption": {
-                "type": [
-                  "string",
-                  "null"
-                ]
-              },
-              "cdnId": {
-                "type": [
-                  "string",
-                  "null"
-                ]
-              },
-              "contentId": {
-                "type": [
-                  "string",
-                  "null"
-                ]
-              },
-              "height": {
-                "format": "int32",
-                "type": [
-                  "integer",
-                  "null"
-                ]
-              },
-              "id": {
-                "type": [
-                  "string",
-                  "null"
-                ]
-              },
-              "location": {
-                "type": [
-                  "string",
-                  "null"
-                ]
-              },
-              "pHash": {
-                "type": [
-                  "string",
-                  "null"
-                ]
-              },
-              "promptId": {
-                "type": [
-                  "string",
-                  "null"
-                ]
-              },
-              "selfieVerified": {
-                "type": [
-                  "boolean",
-                  "null"
-                ]
-              },
-              "source": {
-                "type": [
-                  "string",
-                  "null"
-                ]
-              },
-              "sourceId": {
-                "type": [
-                  "string",
-                  "null"
-                ]
-              },
-              "url": {
-                "type": "string"
-              },
-              "videoUrl": {
-                "type": [
-                  "string",
-                  "null"
-                ]
-              },
-              "width": {
-                "format": "int32",
-                "type": [
-                  "integer",
-                  "null"
-                ]
-              }
-            },
-            "required": [
-              "url"
-            ],
-            "type": "object"
-          },
-          "SortedLikeIdV2": {
-            "properties": {
-              "id": {
-                "type": "string"
-              }
-            },
-            "required": [
-              "id"
-            ],
-            "type": "object"
-          },
-          "SortedLikesGroupV2": {
-            "properties": {
-              "data": {
-                "items": {
-                  "$ref": "#/components/schemas/LikesV2Response/$defs/SortedLikeIdV2"
-                },
-                "type": "array"
-              },
-              "sortID": {
-                "type": "string"
-              }
-            },
-            "required": [
-              "sortID",
-              "data"
-            ],
-            "type": "object"
-          }
-        },
         "properties": {
           "hiddenLikes": {
             "default": [],
@@ -3896,21 +1448,21 @@
           },
           "likes": {
             "items": {
-              "$ref": "#/components/schemas/LikesV2Response/$defs/LikeItemV2"
+              "$ref": "#/components/schemas/LikeItemV2"
             },
             "type": "array"
           },
           "sortedLikes": {
             "default": [],
             "items": {
-              "$ref": "#/components/schemas/LikesV2Response/$defs/SortedLikesGroupV2"
+              "$ref": "#/components/schemas/SortedLikesGroupV2"
             },
             "type": "array"
           },
           "sorts": {
             "default": [],
             "items": {
-              "$ref": "#/components/schemas/LikesV2Response/$defs/LikeSortV2"
+              "$ref": "#/components/schemas/LikeSortV2"
             },
             "type": "array"
           }
@@ -3984,49 +1536,11 @@
         "type": "object"
       },
       "LoginTokens": {
-        "$defs": {
-          "HingeAuthToken": {
-            "properties": {
-              "expires": {
-                "format": "date-time",
-                "type": "string"
-              },
-              "identityId": {
-                "type": "string"
-              },
-              "token": {
-                "type": "string"
-              }
-            },
-            "required": [
-              "identityId",
-              "token",
-              "expires"
-            ],
-            "type": "object"
-          },
-          "SendbirdAuthToken": {
-            "properties": {
-              "expires": {
-                "format": "date-time",
-                "type": "string"
-              },
-              "token": {
-                "type": "string"
-              }
-            },
-            "required": [
-              "token",
-              "expires"
-            ],
-            "type": "object"
-          }
-        },
         "properties": {
           "hingeAuthToken": {
             "anyOf": [
               {
-                "$ref": "#/components/schemas/LoginTokens/$defs/HingeAuthToken"
+                "$ref": "#/components/schemas/HingeAuthToken"
               },
               {
                 "type": "null"
@@ -4037,7 +1551,7 @@
           "sendbirdAuthToken": {
             "anyOf": [
               {
-                "$ref": "#/components/schemas/LoginTokens/$defs/SendbirdAuthToken"
+                "$ref": "#/components/schemas/SendbirdAuthToken"
               },
               {
                 "type": "null"
@@ -4048,6 +1562,41 @@
         },
         "title": "LoginTokens",
         "type": "object"
+      },
+      "MarijuanaStatus": {
+        "properties": {
+          "value": {
+            "$ref": "#/components/schemas/MarijuanaStatusProfile"
+          },
+          "visible": {
+            "type": "boolean"
+          }
+        },
+        "required": [
+          "value",
+          "visible"
+        ],
+        "type": "object"
+      },
+      "MarijuanaStatusPreference": {
+        "enum": [
+          "OpenToAll",
+          "No",
+          "Yes",
+          "Sometimes",
+          "NoPreference"
+        ],
+        "type": "string"
+      },
+      "MarijuanaStatusProfile": {
+        "enum": [
+          "PreferNotToSay",
+          "No",
+          "Yes",
+          "Sometimes",
+          "NoPreference"
+        ],
+        "type": "string"
       },
       "MatchNoteResponse": {
         "properties": {
@@ -4114,47 +1663,11 @@
         "type": "object"
       },
       "PhotoAsset": {
-        "$defs": {
-          "BoundingBox": {
-            "properties": {
-              "bottomRight": {
-                "$ref": "#/components/schemas/PhotoAsset/$defs/Coordinate",
-                "default": {
-                  "x": 0.0,
-                  "y": 0.0
-                }
-              },
-              "topLeft": {
-                "$ref": "#/components/schemas/PhotoAsset/$defs/Coordinate",
-                "default": {
-                  "x": 0.0,
-                  "y": 0.0
-                }
-              }
-            },
-            "type": "object"
-          },
-          "Coordinate": {
-            "properties": {
-              "x": {
-                "default": 0.0,
-                "format": "double",
-                "type": "number"
-              },
-              "y": {
-                "default": 0.0,
-                "format": "double",
-                "type": "number"
-              }
-            },
-            "type": "object"
-          }
-        },
         "properties": {
           "boundingBox": {
             "anyOf": [
               {
-                "$ref": "#/components/schemas/PhotoAsset/$defs/BoundingBox"
+                "$ref": "#/components/schemas/BoundingBox"
               },
               {
                 "type": "null"
@@ -4252,47 +1765,11 @@
         "type": "object"
       },
       "PhotoAssetInput": {
-        "$defs": {
-          "BoundingBox": {
-            "properties": {
-              "bottomRight": {
-                "$ref": "#/components/schemas/PhotoAssetInput/$defs/Coordinate",
-                "default": {
-                  "x": 0.0,
-                  "y": 0.0
-                }
-              },
-              "topLeft": {
-                "$ref": "#/components/schemas/PhotoAssetInput/$defs/Coordinate",
-                "default": {
-                  "x": 0.0,
-                  "y": 0.0
-                }
-              }
-            },
-            "type": "object"
-          },
-          "Coordinate": {
-            "properties": {
-              "x": {
-                "default": 0.0,
-                "format": "double",
-                "type": "number"
-              },
-              "y": {
-                "default": 0.0,
-                "format": "double",
-                "type": "number"
-              }
-            },
-            "type": "object"
-          }
-        },
         "properties": {
           "boundingBox": {
             "anyOf": [
               {
-                "$ref": "#/components/schemas/PhotoAssetInput/$defs/BoundingBox"
+                "$ref": "#/components/schemas/BoundingBox"
               },
               {
                 "type": "null"
@@ -4327,319 +1804,81 @@
         "title": "PhotoAssetInput",
         "type": "object"
       },
-      "Preferences": {
-        "$defs": {
-          "ChildrenStatusPreference": {
-            "enum": [
-              "OpenToAll",
-              "No",
-              "Yes"
-            ],
-            "type": "string"
+      "Politics": {
+        "properties": {
+          "value": {
+            "$ref": "#/components/schemas/PoliticsProfile"
           },
-          "DatingIntentionPreference": {
-            "enum": [
-              "OpenToAll",
-              "LifePartner",
-              "LongTermRelationship",
-              "LongTermOpenToShort",
-              "ShortTermOpenToLong",
-              "ShortTermRelationship",
-              "FiguringOutTheirDatingGoals"
-            ],
-            "type": "string"
-          },
-          "Dealbreakers": {
-            "properties": {
-              "children": {
-                "type": "boolean"
-              },
-              "datingIntentions": {
-                "type": "boolean"
-              },
-              "drinking": {
-                "type": "boolean"
-              },
-              "drugs": {
-                "type": "boolean"
-              },
-              "educationAttained": {
-                "type": "boolean"
-              },
-              "ethnicities": {
-                "type": "boolean"
-              },
-              "familyPlans": {
-                "type": "boolean"
-              },
-              "genderedAge": {
-                "$ref": "#/components/schemas/Preferences/$defs/GenderedDealbreaker"
-              },
-              "genderedHeight": {
-                "$ref": "#/components/schemas/Preferences/$defs/GenderedDealbreaker"
-              },
-              "marijuana": {
-                "type": "boolean"
-              },
-              "maxDistance": {
-                "type": "boolean"
-              },
-              "politics": {
-                "type": "boolean"
-              },
-              "relationshipTypes": {
-                "type": "boolean"
-              },
-              "religions": {
-                "type": "boolean"
-              },
-              "smoking": {
-                "type": "boolean"
-              }
-            },
-            "required": [
-              "marijuana",
-              "smoking",
-              "maxDistance",
-              "drinking",
-              "educationAttained",
-              "genderedHeight",
-              "politics",
-              "relationshipTypes",
-              "drugs",
-              "datingIntentions",
-              "familyPlans",
-              "genderedAge",
-              "religions",
-              "ethnicities",
-              "children"
-            ],
-            "type": "object"
-          },
-          "DrinkingStatusPreference": {
-            "enum": [
-              "OpenToAll",
-              "No",
-              "Yes",
-              "Sometimes"
-            ],
-            "type": "string"
-          },
-          "DrugStatusPreference": {
-            "enum": [
-              "OpenToAll",
-              "No",
-              "Yes",
-              "Sometimes"
-            ],
-            "type": "string"
-          },
-          "EducationAttainedPreference": {
-            "enum": [
-              "OpenToAll",
-              "HighSchool",
-              "TradeSchool",
-              "InCollege",
-              "Undergraduate",
-              "InGradSchool",
-              "Graduate"
-            ],
-            "type": "string"
-          },
-          "EthnicityPreference": {
-            "enum": [
-              "OpenToAll",
-              "AmericanIndian",
-              "BlackAfrican",
-              "EastAsian",
-              "Hispanic",
-              "MiddleEastern",
-              "PacificIslander",
-              "SouthAsian",
-              "White",
-              "Other"
-            ],
-            "type": "string"
-          },
-          "GenderPreferences": {
-            "enum": [
-              "Men",
-              "Women",
-              "Everyone"
-            ],
-            "type": "string"
-          },
-          "GenderedDealbreaker": {
-            "properties": {
-              "0": {
-                "type": [
-                  "boolean",
-                  "null"
-                ]
-              },
-              "1": {
-                "type": [
-                  "boolean",
-                  "null"
-                ]
-              },
-              "3": {
-                "type": [
-                  "boolean",
-                  "null"
-                ]
-              }
-            },
-            "type": "object"
-          },
-          "GenderedRange": {
-            "properties": {
-              "0": {
-                "anyOf": [
-                  {
-                    "$ref": "#/components/schemas/Preferences/$defs/RangeDetails"
-                  },
-                  {
-                    "type": "null"
-                  }
-                ]
-              },
-              "1": {
-                "anyOf": [
-                  {
-                    "$ref": "#/components/schemas/Preferences/$defs/RangeDetails"
-                  },
-                  {
-                    "type": "null"
-                  }
-                ]
-              },
-              "3": {
-                "anyOf": [
-                  {
-                    "$ref": "#/components/schemas/Preferences/$defs/RangeDetails"
-                  },
-                  {
-                    "type": "null"
-                  }
-                ]
-              }
-            },
-            "type": "object"
-          },
-          "MarijuanaStatusPreference": {
-            "enum": [
-              "OpenToAll",
-              "No",
-              "Yes",
-              "Sometimes",
-              "NoPreference"
-            ],
-            "type": "string"
-          },
-          "PoliticsPreference": {
-            "enum": [
-              "OpenToAll",
-              "Liberal",
-              "Moderate",
-              "Conservative",
-              "NotPolitical",
-              "Other"
-            ],
-            "type": "string"
-          },
-          "RangeDetails": {
-            "properties": {
-              "max": {
-                "format": "int32",
-                "type": [
-                  "integer",
-                  "null"
-                ]
-              },
-              "min": {
-                "format": "int32",
-                "type": [
-                  "integer",
-                  "null"
-                ]
-              }
-            },
-            "type": "object"
-          },
-          "RelationshipTypePreference": {
-            "enum": [
-              "OpenToAll",
-              "Monogamy",
-              "EthicalNonMonogamy",
-              "FiguringOutTheirRelationshipType"
-            ],
-            "type": "string"
-          },
-          "ReligionPreference": {
-            "enum": [
-              "OpenToAll",
-              "Spiritual",
-              "Catholic",
-              "Christian",
-              "Hindu",
-              "Jewish",
-              "Muslim",
-              "Buddhist",
-              "Agnostic",
-              "Atheist",
-              "Other",
-              "Sikh"
-            ],
-            "type": "string"
-          },
-          "SmokingStatusPreference": {
-            "enum": [
-              "OpenToAll",
-              "No",
-              "Yes",
-              "Sometimes"
-            ],
-            "type": "string"
+          "visible": {
+            "type": "boolean"
           }
         },
+        "required": [
+          "value",
+          "visible"
+        ],
+        "type": "object"
+      },
+      "PoliticsPreference": {
+        "enum": [
+          "OpenToAll",
+          "Liberal",
+          "Moderate",
+          "Conservative",
+          "NotPolitical",
+          "Other"
+        ],
+        "type": "string"
+      },
+      "PoliticsProfile": {
+        "enum": [
+          "PreferNotToSay",
+          "Liberal",
+          "Moderate",
+          "Conservative",
+          "NotPolitical",
+          "Other"
+        ],
+        "type": "string"
+      },
+      "Preferences": {
         "properties": {
           "children": {
             "items": {
-              "$ref": "#/components/schemas/Preferences/$defs/ChildrenStatusPreference"
+              "$ref": "#/components/schemas/ChildrenStatusPreference"
             },
             "type": "array"
           },
           "datingIntentions": {
             "items": {
-              "$ref": "#/components/schemas/Preferences/$defs/DatingIntentionPreference"
+              "$ref": "#/components/schemas/DatingIntentionPreference"
             },
             "type": "array"
           },
           "dealbreakers": {
-            "$ref": "#/components/schemas/Preferences/$defs/Dealbreakers"
+            "$ref": "#/components/schemas/Dealbreakers"
           },
           "drinking": {
             "items": {
-              "$ref": "#/components/schemas/Preferences/$defs/DrinkingStatusPreference"
+              "$ref": "#/components/schemas/DrinkingStatusPreference"
             },
             "type": "array"
           },
           "drugs": {
             "items": {
-              "$ref": "#/components/schemas/Preferences/$defs/DrugStatusPreference"
+              "$ref": "#/components/schemas/DrugStatusPreference"
             },
             "type": "array"
           },
           "educationAttained": {
             "items": {
-              "$ref": "#/components/schemas/Preferences/$defs/EducationAttainedPreference"
+              "$ref": "#/components/schemas/EducationAttainedPreference"
             },
             "type": "array"
           },
           "ethnicities": {
             "items": {
-              "$ref": "#/components/schemas/Preferences/$defs/EthnicityPreference"
+              "$ref": "#/components/schemas/EthnicityPreference"
             },
             "type": "array"
           },
@@ -4652,19 +1891,19 @@
           },
           "genderPreferences": {
             "items": {
-              "$ref": "#/components/schemas/Preferences/$defs/GenderPreferences"
+              "$ref": "#/components/schemas/GenderPreferences"
             },
             "type": "array"
           },
           "genderedAgeRanges": {
-            "$ref": "#/components/schemas/Preferences/$defs/GenderedRange"
+            "$ref": "#/components/schemas/GenderedRange"
           },
           "genderedHeightRanges": {
-            "$ref": "#/components/schemas/Preferences/$defs/GenderedRange"
+            "$ref": "#/components/schemas/GenderedRange"
           },
           "marijuana": {
             "items": {
-              "$ref": "#/components/schemas/Preferences/$defs/MarijuanaStatusPreference"
+              "$ref": "#/components/schemas/MarijuanaStatusPreference"
             },
             "type": "array"
           },
@@ -4674,25 +1913,25 @@
           },
           "politics": {
             "items": {
-              "$ref": "#/components/schemas/Preferences/$defs/PoliticsPreference"
+              "$ref": "#/components/schemas/PoliticsPreference"
             },
             "type": "array"
           },
           "relationshipTypes": {
             "items": {
-              "$ref": "#/components/schemas/Preferences/$defs/RelationshipTypePreference"
+              "$ref": "#/components/schemas/RelationshipTypePreference"
             },
             "type": "array"
           },
           "religions": {
             "items": {
-              "$ref": "#/components/schemas/Preferences/$defs/ReligionPreference"
+              "$ref": "#/components/schemas/ReligionPreference"
             },
             "type": "array"
           },
           "smoking": {
             "items": {
-              "$ref": "#/components/schemas/Preferences/$defs/SmokingStatusPreference"
+              "$ref": "#/components/schemas/SmokingStatusPreference"
             },
             "type": "array"
           }
@@ -4720,318 +1959,43 @@
         "type": "object"
       },
       "PreferencesResponse": {
-        "$defs": {
-          "ChildrenStatusPreference": {
-            "enum": [
-              "OpenToAll",
-              "No",
-              "Yes"
-            ],
-            "type": "string"
-          },
-          "DatingIntentionPreference": {
-            "enum": [
-              "OpenToAll",
-              "LifePartner",
-              "LongTermRelationship",
-              "LongTermOpenToShort",
-              "ShortTermOpenToLong",
-              "ShortTermRelationship",
-              "FiguringOutTheirDatingGoals"
-            ],
-            "type": "string"
-          },
-          "Dealbreakers": {
-            "properties": {
-              "children": {
-                "type": "boolean"
-              },
-              "datingIntentions": {
-                "type": "boolean"
-              },
-              "drinking": {
-                "type": "boolean"
-              },
-              "drugs": {
-                "type": "boolean"
-              },
-              "educationAttained": {
-                "type": "boolean"
-              },
-              "ethnicities": {
-                "type": "boolean"
-              },
-              "familyPlans": {
-                "type": "boolean"
-              },
-              "genderedAge": {
-                "$ref": "#/components/schemas/PreferencesResponse/$defs/GenderedDealbreaker"
-              },
-              "genderedHeight": {
-                "$ref": "#/components/schemas/PreferencesResponse/$defs/GenderedDealbreaker"
-              },
-              "marijuana": {
-                "type": "boolean"
-              },
-              "maxDistance": {
-                "type": "boolean"
-              },
-              "politics": {
-                "type": "boolean"
-              },
-              "relationshipTypes": {
-                "type": "boolean"
-              },
-              "religions": {
-                "type": "boolean"
-              },
-              "smoking": {
-                "type": "boolean"
-              }
-            },
-            "required": [
-              "marijuana",
-              "smoking",
-              "maxDistance",
-              "drinking",
-              "educationAttained",
-              "genderedHeight",
-              "politics",
-              "relationshipTypes",
-              "drugs",
-              "datingIntentions",
-              "familyPlans",
-              "genderedAge",
-              "religions",
-              "ethnicities",
-              "children"
-            ],
-            "type": "object"
-          },
-          "DrinkingStatusPreference": {
-            "enum": [
-              "OpenToAll",
-              "No",
-              "Yes",
-              "Sometimes"
-            ],
-            "type": "string"
-          },
-          "DrugStatusPreference": {
-            "enum": [
-              "OpenToAll",
-              "No",
-              "Yes",
-              "Sometimes"
-            ],
-            "type": "string"
-          },
-          "EducationAttainedPreference": {
-            "enum": [
-              "OpenToAll",
-              "HighSchool",
-              "TradeSchool",
-              "InCollege",
-              "Undergraduate",
-              "InGradSchool",
-              "Graduate"
-            ],
-            "type": "string"
-          },
-          "EthnicityPreference": {
-            "enum": [
-              "OpenToAll",
-              "AmericanIndian",
-              "BlackAfrican",
-              "EastAsian",
-              "Hispanic",
-              "MiddleEastern",
-              "PacificIslander",
-              "SouthAsian",
-              "White",
-              "Other"
-            ],
-            "type": "string"
-          },
-          "GenderPreferences": {
-            "enum": [
-              "Men",
-              "Women",
-              "Everyone"
-            ],
-            "type": "string"
-          },
-          "GenderedDealbreaker": {
-            "properties": {
-              "0": {
-                "type": [
-                  "boolean",
-                  "null"
-                ]
-              },
-              "1": {
-                "type": [
-                  "boolean",
-                  "null"
-                ]
-              },
-              "3": {
-                "type": [
-                  "boolean",
-                  "null"
-                ]
-              }
-            },
-            "type": "object"
-          },
-          "GenderedRange": {
-            "properties": {
-              "0": {
-                "anyOf": [
-                  {
-                    "$ref": "#/components/schemas/PreferencesResponse/$defs/RangeDetails"
-                  },
-                  {
-                    "type": "null"
-                  }
-                ]
-              },
-              "1": {
-                "anyOf": [
-                  {
-                    "$ref": "#/components/schemas/PreferencesResponse/$defs/RangeDetails"
-                  },
-                  {
-                    "type": "null"
-                  }
-                ]
-              },
-              "3": {
-                "anyOf": [
-                  {
-                    "$ref": "#/components/schemas/PreferencesResponse/$defs/RangeDetails"
-                  },
-                  {
-                    "type": "null"
-                  }
-                ]
-              }
-            },
-            "type": "object"
-          },
-          "MarijuanaStatusPreference": {
-            "enum": [
-              "OpenToAll",
-              "No",
-              "Yes",
-              "Sometimes",
-              "NoPreference"
-            ],
-            "type": "string"
-          },
-          "PoliticsPreference": {
-            "enum": [
-              "OpenToAll",
-              "Liberal",
-              "Moderate",
-              "Conservative",
-              "NotPolitical",
-              "Other"
-            ],
-            "type": "string"
-          },
-          "RangeDetails": {
-            "properties": {
-              "max": {
-                "format": "int32",
-                "type": [
-                  "integer",
-                  "null"
-                ]
-              },
-              "min": {
-                "format": "int32",
-                "type": [
-                  "integer",
-                  "null"
-                ]
-              }
-            },
-            "type": "object"
-          },
-          "RelationshipTypePreference": {
-            "enum": [
-              "OpenToAll",
-              "Monogamy",
-              "EthicalNonMonogamy",
-              "FiguringOutTheirRelationshipType"
-            ],
-            "type": "string"
-          },
-          "ReligionPreference": {
-            "enum": [
-              "OpenToAll",
-              "Spiritual",
-              "Catholic",
-              "Christian",
-              "Hindu",
-              "Jewish",
-              "Muslim",
-              "Buddhist",
-              "Agnostic",
-              "Atheist",
-              "Other",
-              "Sikh"
-            ],
-            "type": "string"
-          },
-          "SmokingStatusPreference": {
-            "enum": [
-              "OpenToAll",
-              "No",
-              "Yes",
-              "Sometimes"
-            ],
-            "type": "string"
-          }
-        },
         "properties": {
           "children": {
             "items": {
-              "$ref": "#/components/schemas/PreferencesResponse/$defs/ChildrenStatusPreference"
+              "$ref": "#/components/schemas/ChildrenStatusPreference"
             },
             "type": "array"
           },
           "datingIntentions": {
             "items": {
-              "$ref": "#/components/schemas/PreferencesResponse/$defs/DatingIntentionPreference"
+              "$ref": "#/components/schemas/DatingIntentionPreference"
             },
             "type": "array"
           },
           "dealbreakers": {
-            "$ref": "#/components/schemas/PreferencesResponse/$defs/Dealbreakers"
+            "$ref": "#/components/schemas/Dealbreakers"
           },
           "drinking": {
             "items": {
-              "$ref": "#/components/schemas/PreferencesResponse/$defs/DrinkingStatusPreference"
+              "$ref": "#/components/schemas/DrinkingStatusPreference"
             },
             "type": "array"
           },
           "drugs": {
             "items": {
-              "$ref": "#/components/schemas/PreferencesResponse/$defs/DrugStatusPreference"
+              "$ref": "#/components/schemas/DrugStatusPreference"
             },
             "type": "array"
           },
           "educationAttained": {
             "items": {
-              "$ref": "#/components/schemas/PreferencesResponse/$defs/EducationAttainedPreference"
+              "$ref": "#/components/schemas/EducationAttainedPreference"
             },
             "type": "array"
           },
           "ethnicities": {
             "items": {
-              "$ref": "#/components/schemas/PreferencesResponse/$defs/EthnicityPreference"
+              "$ref": "#/components/schemas/EthnicityPreference"
             },
             "type": "array"
           },
@@ -5044,19 +2008,19 @@
           },
           "genderPreferences": {
             "items": {
-              "$ref": "#/components/schemas/PreferencesResponse/$defs/GenderPreferences"
+              "$ref": "#/components/schemas/GenderPreferences"
             },
             "type": "array"
           },
           "genderedAgeRanges": {
-            "$ref": "#/components/schemas/PreferencesResponse/$defs/GenderedRange"
+            "$ref": "#/components/schemas/GenderedRange"
           },
           "genderedHeightRanges": {
-            "$ref": "#/components/schemas/PreferencesResponse/$defs/GenderedRange"
+            "$ref": "#/components/schemas/GenderedRange"
           },
           "marijuana": {
             "items": {
-              "$ref": "#/components/schemas/PreferencesResponse/$defs/MarijuanaStatusPreference"
+              "$ref": "#/components/schemas/MarijuanaStatusPreference"
             },
             "type": "array"
           },
@@ -5066,25 +2030,25 @@
           },
           "politics": {
             "items": {
-              "$ref": "#/components/schemas/PreferencesResponse/$defs/PoliticsPreference"
+              "$ref": "#/components/schemas/PoliticsPreference"
             },
             "type": "array"
           },
           "relationshipTypes": {
             "items": {
-              "$ref": "#/components/schemas/PreferencesResponse/$defs/RelationshipTypePreference"
+              "$ref": "#/components/schemas/RelationshipTypePreference"
             },
             "type": "array"
           },
           "religions": {
             "items": {
-              "$ref": "#/components/schemas/PreferencesResponse/$defs/ReligionPreference"
+              "$ref": "#/components/schemas/ReligionPreference"
             },
             "type": "array"
           },
           "smoking": {
             "items": {
-              "$ref": "#/components/schemas/PreferencesResponse/$defs/SmokingStatusPreference"
+              "$ref": "#/components/schemas/SmokingStatusPreference"
             },
             "type": "array"
           }
@@ -5118,780 +2082,6 @@
         "type": "array"
       },
       "Profile": {
-        "$defs": {
-          "BoundingBox": {
-            "properties": {
-              "bottomRight": {
-                "$ref": "#/components/schemas/Profile/$defs/Coordinate",
-                "default": {
-                  "x": 0.0,
-                  "y": 0.0
-                }
-              },
-              "topLeft": {
-                "$ref": "#/components/schemas/Profile/$defs/Coordinate",
-                "default": {
-                  "x": 0.0,
-                  "y": 0.0
-                }
-              }
-            },
-            "type": "object"
-          },
-          "ChildrenStatus": {
-            "properties": {
-              "value": {
-                "$ref": "#/components/schemas/Profile/$defs/ChildrenStatusProfile"
-              },
-              "visible": {
-                "type": "boolean"
-              }
-            },
-            "required": [
-              "value",
-              "visible"
-            ],
-            "type": "object"
-          },
-          "ChildrenStatusProfile": {
-            "enum": [
-              "PreferNotToSay",
-              "No",
-              "Yes"
-            ],
-            "type": "string"
-          },
-          "Coordinate": {
-            "properties": {
-              "x": {
-                "default": 0.0,
-                "format": "double",
-                "type": "number"
-              },
-              "y": {
-                "default": 0.0,
-                "format": "double",
-                "type": "number"
-              }
-            },
-            "type": "object"
-          },
-          "DatingIntention": {
-            "properties": {
-              "value": {
-                "$ref": "#/components/schemas/Profile/$defs/DatingIntentionProfile"
-              },
-              "visible": {
-                "type": "boolean"
-              }
-            },
-            "required": [
-              "value",
-              "visible"
-            ],
-            "type": "object"
-          },
-          "DatingIntentionProfile": {
-            "enum": [
-              "PreferNotToSay",
-              "LifePartner",
-              "LongTermRelationship",
-              "LongTermOpenToShort",
-              "ShortTermOpenToLong",
-              "ShortTermRelationship",
-              "FiguringOutTheirDatingGoals"
-            ],
-            "type": "string"
-          },
-          "DrinkingStatus": {
-            "properties": {
-              "value": {
-                "$ref": "#/components/schemas/Profile/$defs/DrinkingStatusProfile"
-              },
-              "visible": {
-                "type": "boolean"
-              }
-            },
-            "required": [
-              "value",
-              "visible"
-            ],
-            "type": "object"
-          },
-          "DrinkingStatusProfile": {
-            "enum": [
-              "PreferNotToSay",
-              "No",
-              "Yes",
-              "Sometimes"
-            ],
-            "type": "string"
-          },
-          "DrugStatus": {
-            "properties": {
-              "value": {
-                "$ref": "#/components/schemas/Profile/$defs/DrugStatusProfile"
-              },
-              "visible": {
-                "type": "boolean"
-              }
-            },
-            "required": [
-              "value",
-              "visible"
-            ],
-            "type": "object"
-          },
-          "DrugStatusProfile": {
-            "enum": [
-              "PreferNotToSay",
-              "No",
-              "Yes",
-              "Sometimes"
-            ],
-            "type": "string"
-          },
-          "EducationAttainedProfile": {
-            "enum": [
-              "PreferNotToSay",
-              "HighSchool",
-              "TradeSchool",
-              "InCollege",
-              "Undergraduate",
-              "InGradSchool",
-              "Graduate"
-            ],
-            "type": "string"
-          },
-          "Educations": {
-            "properties": {
-              "value": {
-                "items": {
-                  "type": "string"
-                },
-                "type": "array"
-              },
-              "visible": {
-                "type": "boolean"
-              }
-            },
-            "required": [
-              "value",
-              "visible"
-            ],
-            "type": "object"
-          },
-          "Ethnicities": {
-            "properties": {
-              "value": {
-                "items": {
-                  "$ref": "#/components/schemas/Profile/$defs/EthnicityProfile"
-                },
-                "type": "array"
-              },
-              "visible": {
-                "type": "boolean"
-              }
-            },
-            "required": [
-              "value",
-              "visible"
-            ],
-            "type": "object"
-          },
-          "EthnicityProfile": {
-            "enum": [
-              "PreferNotToSay",
-              "AmericanIndian",
-              "BlackAfrican",
-              "EastAsian",
-              "Hispanic",
-              "MiddleEastern",
-              "PacificIslander",
-              "SouthAsian",
-              "White",
-              "Other"
-            ],
-            "type": "string"
-          },
-          "FamilyPlans": {
-            "properties": {
-              "value": {
-                "format": "int32",
-                "type": "integer"
-              },
-              "visible": {
-                "type": "boolean"
-              }
-            },
-            "required": [
-              "value",
-              "visible"
-            ],
-            "type": "object"
-          },
-          "Feedback": {
-            "properties": {
-              "detail": {
-                "type": "string"
-              },
-              "evaluation": {
-                "type": "string"
-              },
-              "feedbackToken": {
-                "type": "string"
-              }
-            },
-            "required": [
-              "evaluation",
-              "detail",
-              "feedbackToken"
-            ],
-            "type": "object"
-          },
-          "GenderEnum": {
-            "enum": [
-              "Man",
-              "Woman",
-              "NonBinary"
-            ],
-            "type": "string"
-          },
-          "GenderIdentityId": {
-            "properties": {
-              "value": {
-                "format": "int32",
-                "type": "integer"
-              },
-              "visible": {
-                "type": "boolean"
-              }
-            },
-            "required": [
-              "value",
-              "visible"
-            ],
-            "type": "object"
-          },
-          "Hometown": {
-            "properties": {
-              "value": {
-                "type": "string"
-              },
-              "visible": {
-                "type": "boolean"
-              }
-            },
-            "required": [
-              "value",
-              "visible"
-            ],
-            "type": "object"
-          },
-          "JobTitle": {
-            "properties": {
-              "value": {
-                "type": "string"
-              },
-              "visible": {
-                "type": "boolean"
-              }
-            },
-            "required": [
-              "value",
-              "visible"
-            ],
-            "type": "object"
-          },
-          "LanguagesSpoken": {
-            "properties": {
-              "value": {
-                "items": {
-                  "format": "int32",
-                  "type": "integer"
-                },
-                "type": "array"
-              },
-              "visible": {
-                "type": "boolean"
-              }
-            },
-            "required": [
-              "value",
-              "visible"
-            ],
-            "type": "object"
-          },
-          "Location": {
-            "properties": {
-              "adminArea1Long": {
-                "type": [
-                  "string",
-                  "null"
-                ]
-              },
-              "adminArea1Short": {
-                "type": [
-                  "string",
-                  "null"
-                ]
-              },
-              "adminArea2": {
-                "type": [
-                  "string",
-                  "null"
-                ]
-              },
-              "countryShort": {
-                "type": [
-                  "string",
-                  "null"
-                ]
-              },
-              "latitude": {
-                "format": "double",
-                "type": [
-                  "number",
-                  "null"
-                ]
-              },
-              "longitude": {
-                "format": "double",
-                "type": [
-                  "number",
-                  "null"
-                ]
-              },
-              "metroArea": {
-                "type": [
-                  "string",
-                  "null"
-                ]
-              },
-              "metroAreaV2": {
-                "type": [
-                  "string",
-                  "null"
-                ]
-              },
-              "name": {
-                "type": "string"
-              }
-            },
-            "required": [
-              "name"
-            ],
-            "type": "object"
-          },
-          "MarijuanaStatus": {
-            "properties": {
-              "value": {
-                "$ref": "#/components/schemas/Profile/$defs/MarijuanaStatusProfile"
-              },
-              "visible": {
-                "type": "boolean"
-              }
-            },
-            "required": [
-              "value",
-              "visible"
-            ],
-            "type": "object"
-          },
-          "MarijuanaStatusProfile": {
-            "enum": [
-              "PreferNotToSay",
-              "No",
-              "Yes",
-              "Sometimes",
-              "NoPreference"
-            ],
-            "type": "string"
-          },
-          "PhotoAsset": {
-            "properties": {
-              "boundingBox": {
-                "anyOf": [
-                  {
-                    "$ref": "#/components/schemas/Profile/$defs/BoundingBox"
-                  },
-                  {
-                    "type": "null"
-                  }
-                ]
-              },
-              "caption": {
-                "type": [
-                  "string",
-                  "null"
-                ]
-              },
-              "cdnId": {
-                "type": [
-                  "string",
-                  "null"
-                ]
-              },
-              "contentId": {
-                "type": [
-                  "string",
-                  "null"
-                ]
-              },
-              "height": {
-                "format": "int32",
-                "type": [
-                  "integer",
-                  "null"
-                ]
-              },
-              "id": {
-                "type": [
-                  "string",
-                  "null"
-                ]
-              },
-              "location": {
-                "type": [
-                  "string",
-                  "null"
-                ]
-              },
-              "pHash": {
-                "type": [
-                  "string",
-                  "null"
-                ]
-              },
-              "promptId": {
-                "type": [
-                  "string",
-                  "null"
-                ]
-              },
-              "selfieVerified": {
-                "type": [
-                  "boolean",
-                  "null"
-                ]
-              },
-              "source": {
-                "type": [
-                  "string",
-                  "null"
-                ]
-              },
-              "sourceId": {
-                "type": [
-                  "string",
-                  "null"
-                ]
-              },
-              "url": {
-                "type": "string"
-              },
-              "videoUrl": {
-                "type": [
-                  "string",
-                  "null"
-                ]
-              },
-              "width": {
-                "format": "int32",
-                "type": [
-                  "integer",
-                  "null"
-                ]
-              }
-            },
-            "required": [
-              "url"
-            ],
-            "type": "object"
-          },
-          "Politics": {
-            "properties": {
-              "value": {
-                "$ref": "#/components/schemas/Profile/$defs/PoliticsProfile"
-              },
-              "visible": {
-                "type": "boolean"
-              }
-            },
-            "required": [
-              "value",
-              "visible"
-            ],
-            "type": "object"
-          },
-          "PoliticsProfile": {
-            "enum": [
-              "PreferNotToSay",
-              "Liberal",
-              "Moderate",
-              "Conservative",
-              "NotPolitical",
-              "Other"
-            ],
-            "type": "string"
-          },
-          "ProfileAnswer": {
-            "properties": {
-              "cdnId": {
-                "type": [
-                  "string",
-                  "null"
-                ]
-              },
-              "content": {
-                "type": [
-                  "string",
-                  "null"
-                ]
-              },
-              "contentId": {
-                "type": [
-                  "string",
-                  "null"
-                ]
-              },
-              "feedback": {
-                "anyOf": [
-                  {
-                    "$ref": "#/components/schemas/Profile/$defs/Feedback"
-                  },
-                  {
-                    "type": "null"
-                  }
-                ]
-              },
-              "position": {
-                "format": "int32",
-                "type": [
-                  "integer",
-                  "null"
-                ]
-              },
-              "promptId": {
-                "type": [
-                  "string",
-                  "null"
-                ]
-              },
-              "questionId": {
-                "type": [
-                  "string",
-                  "null"
-                ]
-              },
-              "response": {
-                "type": [
-                  "string",
-                  "null"
-                ]
-              },
-              "transcription": {
-                "type": [
-                  "string",
-                  "null"
-                ]
-              },
-              "transcriptionMetadata": true,
-              "type": {
-                "type": [
-                  "string",
-                  "null"
-                ]
-              },
-              "url": {
-                "type": [
-                  "string",
-                  "null"
-                ]
-              },
-              "waveform": {
-                "type": [
-                  "string",
-                  "null"
-                ]
-              }
-            },
-            "type": "object"
-          },
-          "ProfileName": {
-            "properties": {
-              "firstName": {
-                "type": "string"
-              },
-              "lastName": {
-                "default": null,
-                "type": [
-                  "string",
-                  "null"
-                ]
-              }
-            },
-            "required": [
-              "firstName"
-            ],
-            "type": "object"
-          },
-          "Pronouns": {
-            "properties": {
-              "value": {
-                "items": {
-                  "format": "int32",
-                  "type": "integer"
-                },
-                "type": "array"
-              },
-              "visible": {
-                "type": "boolean"
-              }
-            },
-            "required": [
-              "value",
-              "visible"
-            ],
-            "type": "object"
-          },
-          "RelationshipTypeIds": {
-            "properties": {
-              "value": {
-                "items": {
-                  "$ref": "#/components/schemas/Profile/$defs/RelationshipTypeProfile"
-                },
-                "type": "array"
-              },
-              "visible": {
-                "type": "boolean"
-              }
-            },
-            "required": [
-              "value",
-              "visible"
-            ],
-            "type": "object"
-          },
-          "RelationshipTypeProfile": {
-            "enum": [
-              "PreferNotToSay",
-              "Monogamy",
-              "EthicalNonMonogamy",
-              "FiguringOutTheirRelationshipType"
-            ],
-            "type": "string"
-          },
-          "Religion": {
-            "properties": {
-              "value": {
-                "items": {
-                  "$ref": "#/components/schemas/Profile/$defs/ReligionProfile"
-                },
-                "type": "array"
-              },
-              "visible": {
-                "type": "boolean"
-              }
-            },
-            "required": [
-              "value",
-              "visible"
-            ],
-            "type": "object"
-          },
-          "ReligionProfile": {
-            "enum": [
-              "PreferNotToSay",
-              "Spiritual",
-              "Catholic",
-              "Christian",
-              "Hindu",
-              "Jewish",
-              "Muslim",
-              "Buddhist",
-              "Agnostic",
-              "Atheist",
-              "Other",
-              "Sikh"
-            ],
-            "type": "string"
-          },
-          "SexualOrientations": {
-            "properties": {
-              "value": {
-                "items": {
-                  "format": "int32",
-                  "type": "integer"
-                },
-                "type": "array"
-              },
-              "visible": {
-                "type": "boolean"
-              }
-            },
-            "required": [
-              "value",
-              "visible"
-            ],
-            "type": "object"
-          },
-          "SmokingStatus": {
-            "properties": {
-              "value": {
-                "$ref": "#/components/schemas/Profile/$defs/SmokingStatusProfile"
-              },
-              "visible": {
-                "type": "boolean"
-              }
-            },
-            "required": [
-              "value",
-              "visible"
-            ],
-            "type": "object"
-          },
-          "SmokingStatusProfile": {
-            "enum": [
-              "PreferNotToSay",
-              "No",
-              "Yes",
-              "Sometimes"
-            ],
-            "type": "string"
-          },
-          "Works": {
-            "properties": {
-              "value": {
-                "type": "string"
-              },
-              "visible": {
-                "type": "boolean"
-              }
-            },
-            "required": [
-              "value",
-              "visible"
-            ],
-            "type": "object"
-          },
-          "Zodiac": {
-            "properties": {
-              "value": {
-                "format": "int32",
-                "type": "integer"
-              },
-              "visible": {
-                "type": "boolean"
-              }
-            },
-            "required": [
-              "value",
-              "visible"
-            ],
-            "type": "object"
-          }
-        },
         "properties": {
           "age": {
             "format": "int32",
@@ -5903,7 +2093,7 @@
           "answers": {
             "default": [],
             "items": {
-              "$ref": "#/components/schemas/Profile/$defs/ProfileAnswer"
+              "$ref": "#/components/schemas/ProfileAnswer"
             },
             "type": "array"
           },
@@ -5916,7 +2106,7 @@
           "children": {
             "anyOf": [
               {
-                "$ref": "#/components/schemas/Profile/$defs/ChildrenStatus"
+                "$ref": "#/components/schemas/ChildrenStatus"
               },
               {
                 "type": "null"
@@ -5933,7 +2123,7 @@
           "datingIntention": {
             "anyOf": [
               {
-                "$ref": "#/components/schemas/Profile/$defs/DatingIntention"
+                "$ref": "#/components/schemas/DatingIntention"
               },
               {
                 "type": "null"
@@ -5955,7 +2145,7 @@
           "drinking": {
             "anyOf": [
               {
-                "$ref": "#/components/schemas/Profile/$defs/DrinkingStatus"
+                "$ref": "#/components/schemas/DrinkingStatus"
               },
               {
                 "type": "null"
@@ -5965,7 +2155,7 @@
           "drugs": {
             "anyOf": [
               {
-                "$ref": "#/components/schemas/Profile/$defs/DrugStatus"
+                "$ref": "#/components/schemas/DrugStatus"
               },
               {
                 "type": "null"
@@ -5975,7 +2165,7 @@
           "educationAttained": {
             "anyOf": [
               {
-                "$ref": "#/components/schemas/Profile/$defs/EducationAttainedProfile"
+                "$ref": "#/components/schemas/EducationAttainedProfile"
               },
               {
                 "type": "null"
@@ -5985,7 +2175,7 @@
           "educations": {
             "anyOf": [
               {
-                "$ref": "#/components/schemas/Profile/$defs/Educations"
+                "$ref": "#/components/schemas/Educations"
               },
               {
                 "type": "null"
@@ -6007,7 +2197,7 @@
           "ethnicities": {
             "anyOf": [
               {
-                "$ref": "#/components/schemas/Profile/$defs/Ethnicities"
+                "$ref": "#/components/schemas/Ethnicities"
               },
               {
                 "type": "null"
@@ -6023,7 +2213,7 @@
           "familyPlans": {
             "anyOf": [
               {
-                "$ref": "#/components/schemas/Profile/$defs/FamilyPlans"
+                "$ref": "#/components/schemas/FamilyPlans"
               },
               {
                 "type": "null"
@@ -6042,7 +2232,7 @@
           "genderId": {
             "anyOf": [
               {
-                "$ref": "#/components/schemas/Profile/$defs/GenderEnum"
+                "$ref": "#/components/schemas/GenderEnum"
               },
               {
                 "type": "null"
@@ -6058,7 +2248,7 @@
           "genderIdentityId": {
             "anyOf": [
               {
-                "$ref": "#/components/schemas/Profile/$defs/GenderIdentityId"
+                "$ref": "#/components/schemas/GenderIdentityId"
               },
               {
                 "type": "null"
@@ -6075,7 +2265,7 @@
           "hometown": {
             "anyOf": [
               {
-                "$ref": "#/components/schemas/Profile/$defs/Hometown"
+                "$ref": "#/components/schemas/Hometown"
               },
               {
                 "type": "null"
@@ -6085,7 +2275,7 @@
           "jobTitle": {
             "anyOf": [
               {
-                "$ref": "#/components/schemas/Profile/$defs/JobTitle"
+                "$ref": "#/components/schemas/JobTitle"
               },
               {
                 "type": "null"
@@ -6095,7 +2285,7 @@
           "languagesSpoken": {
             "anyOf": [
               {
-                "$ref": "#/components/schemas/Profile/$defs/LanguagesSpoken"
+                "$ref": "#/components/schemas/LanguagesSpoken"
               },
               {
                 "type": "null"
@@ -6116,12 +2306,12 @@
             ]
           },
           "location": {
-            "$ref": "#/components/schemas/Profile/$defs/Location"
+            "$ref": "#/components/schemas/Location"
           },
           "marijuana": {
             "anyOf": [
               {
-                "$ref": "#/components/schemas/Profile/$defs/MarijuanaStatus"
+                "$ref": "#/components/schemas/MarijuanaStatus"
               },
               {
                 "type": "null"
@@ -6131,7 +2321,7 @@
           "name": {
             "anyOf": [
               {
-                "$ref": "#/components/schemas/Profile/$defs/ProfileName"
+                "$ref": "#/components/schemas/ProfileName"
               },
               {
                 "type": "null"
@@ -6148,14 +2338,14 @@
           "photos": {
             "default": [],
             "items": {
-              "$ref": "#/components/schemas/Profile/$defs/PhotoAsset"
+              "$ref": "#/components/schemas/PhotoAsset"
             },
             "type": "array"
           },
           "politics": {
             "anyOf": [
               {
-                "$ref": "#/components/schemas/Profile/$defs/Politics"
+                "$ref": "#/components/schemas/Politics"
               },
               {
                 "type": "null"
@@ -6165,7 +2355,7 @@
           "pronouns": {
             "anyOf": [
               {
-                "$ref": "#/components/schemas/Profile/$defs/Pronouns"
+                "$ref": "#/components/schemas/Pronouns"
               },
               {
                 "type": "null"
@@ -6175,7 +2365,7 @@
           "relationshipTypeIds": {
             "anyOf": [
               {
-                "$ref": "#/components/schemas/Profile/$defs/RelationshipTypeIds"
+                "$ref": "#/components/schemas/RelationshipTypeIds"
               },
               {
                 "type": "null"
@@ -6191,7 +2381,7 @@
           "religions": {
             "anyOf": [
               {
-                "$ref": "#/components/schemas/Profile/$defs/Religion"
+                "$ref": "#/components/schemas/Religion"
               },
               {
                 "type": "null"
@@ -6207,7 +2397,7 @@
           "sexualOrientations": {
             "anyOf": [
               {
-                "$ref": "#/components/schemas/Profile/$defs/SexualOrientations"
+                "$ref": "#/components/schemas/SexualOrientations"
               },
               {
                 "type": "null"
@@ -6217,7 +2407,7 @@
           "smoking": {
             "anyOf": [
               {
-                "$ref": "#/components/schemas/Profile/$defs/SmokingStatus"
+                "$ref": "#/components/schemas/SmokingStatus"
               },
               {
                 "type": "null"
@@ -6227,7 +2417,7 @@
           "works": {
             "anyOf": [
               {
-                "$ref": "#/components/schemas/Profile/$defs/Works"
+                "$ref": "#/components/schemas/Works"
               },
               {
                 "type": "null"
@@ -6237,7 +2427,7 @@
           "zodiac": {
             "anyOf": [
               {
-                "$ref": "#/components/schemas/Profile/$defs/Zodiac"
+                "$ref": "#/components/schemas/Zodiac"
               },
               {
                 "type": "null"
@@ -6253,27 +2443,6 @@
         "type": "object"
       },
       "ProfileAnswer": {
-        "$defs": {
-          "Feedback": {
-            "properties": {
-              "detail": {
-                "type": "string"
-              },
-              "evaluation": {
-                "type": "string"
-              },
-              "feedbackToken": {
-                "type": "string"
-              }
-            },
-            "required": [
-              "evaluation",
-              "detail",
-              "feedbackToken"
-            ],
-            "type": "object"
-          }
-        },
         "properties": {
           "cdnId": {
             "type": [
@@ -6296,7 +2465,7 @@
           "feedback": {
             "anyOf": [
               {
-                "$ref": "#/components/schemas/ProfileAnswer/$defs/Feedback"
+                "$ref": "#/components/schemas/Feedback"
               },
               {
                 "type": "null"
@@ -6358,278 +2527,21 @@
         "type": "object"
       },
       "ProfileContent": {
-        "$defs": {
-          "BoundingBox": {
-            "properties": {
-              "bottomRight": {
-                "$ref": "#/components/schemas/ProfileContent/$defs/Coordinate",
-                "default": {
-                  "x": 0.0,
-                  "y": 0.0
-                }
-              },
-              "topLeft": {
-                "$ref": "#/components/schemas/ProfileContent/$defs/Coordinate",
-                "default": {
-                  "x": 0.0,
-                  "y": 0.0
-                }
-              }
-            },
-            "type": "object"
-          },
-          "Coordinate": {
-            "properties": {
-              "x": {
-                "default": 0.0,
-                "format": "double",
-                "type": "number"
-              },
-              "y": {
-                "default": 0.0,
-                "format": "double",
-                "type": "number"
-              }
-            },
-            "type": "object"
-          },
-          "Feedback": {
-            "properties": {
-              "detail": {
-                "type": "string"
-              },
-              "evaluation": {
-                "type": "string"
-              },
-              "feedbackToken": {
-                "type": "string"
-              }
-            },
-            "required": [
-              "evaluation",
-              "detail",
-              "feedbackToken"
-            ],
-            "type": "object"
-          },
-          "PhotoAsset": {
-            "properties": {
-              "boundingBox": {
-                "anyOf": [
-                  {
-                    "$ref": "#/components/schemas/ProfileContent/$defs/BoundingBox"
-                  },
-                  {
-                    "type": "null"
-                  }
-                ]
-              },
-              "caption": {
-                "type": [
-                  "string",
-                  "null"
-                ]
-              },
-              "cdnId": {
-                "type": [
-                  "string",
-                  "null"
-                ]
-              },
-              "contentId": {
-                "type": [
-                  "string",
-                  "null"
-                ]
-              },
-              "height": {
-                "format": "int32",
-                "type": [
-                  "integer",
-                  "null"
-                ]
-              },
-              "id": {
-                "type": [
-                  "string",
-                  "null"
-                ]
-              },
-              "location": {
-                "type": [
-                  "string",
-                  "null"
-                ]
-              },
-              "pHash": {
-                "type": [
-                  "string",
-                  "null"
-                ]
-              },
-              "promptId": {
-                "type": [
-                  "string",
-                  "null"
-                ]
-              },
-              "selfieVerified": {
-                "type": [
-                  "boolean",
-                  "null"
-                ]
-              },
-              "source": {
-                "type": [
-                  "string",
-                  "null"
-                ]
-              },
-              "sourceId": {
-                "type": [
-                  "string",
-                  "null"
-                ]
-              },
-              "url": {
-                "type": "string"
-              },
-              "videoUrl": {
-                "type": [
-                  "string",
-                  "null"
-                ]
-              },
-              "width": {
-                "format": "int32",
-                "type": [
-                  "integer",
-                  "null"
-                ]
-              }
-            },
-            "required": [
-              "url"
-            ],
-            "type": "object"
-          },
-          "ProfileAnswer": {
-            "properties": {
-              "cdnId": {
-                "type": [
-                  "string",
-                  "null"
-                ]
-              },
-              "content": {
-                "type": [
-                  "string",
-                  "null"
-                ]
-              },
-              "contentId": {
-                "type": [
-                  "string",
-                  "null"
-                ]
-              },
-              "feedback": {
-                "anyOf": [
-                  {
-                    "$ref": "#/components/schemas/ProfileContent/$defs/Feedback"
-                  },
-                  {
-                    "type": "null"
-                  }
-                ]
-              },
-              "position": {
-                "format": "int32",
-                "type": [
-                  "integer",
-                  "null"
-                ]
-              },
-              "promptId": {
-                "type": [
-                  "string",
-                  "null"
-                ]
-              },
-              "questionId": {
-                "type": [
-                  "string",
-                  "null"
-                ]
-              },
-              "response": {
-                "type": [
-                  "string",
-                  "null"
-                ]
-              },
-              "transcription": {
-                "type": [
-                  "string",
-                  "null"
-                ]
-              },
-              "transcriptionMetadata": true,
-              "type": {
-                "type": [
-                  "string",
-                  "null"
-                ]
-              },
-              "url": {
-                "type": [
-                  "string",
-                  "null"
-                ]
-              },
-              "waveform": {
-                "type": [
-                  "string",
-                  "null"
-                ]
-              }
-            },
-            "type": "object"
-          },
-          "ProfileName": {
-            "properties": {
-              "firstName": {
-                "type": "string"
-              },
-              "lastName": {
-                "default": null,
-                "type": [
-                  "string",
-                  "null"
-                ]
-              }
-            },
-            "required": [
-              "firstName"
-            ],
-            "type": "object"
-          }
-        },
         "properties": {
           "answers": {
             "default": [],
             "items": {
-              "$ref": "#/components/schemas/ProfileContent/$defs/ProfileAnswer"
+              "$ref": "#/components/schemas/ProfileAnswer"
             },
             "type": "array"
           },
           "name": {
-            "$ref": "#/components/schemas/ProfileContent/$defs/ProfileName"
+            "$ref": "#/components/schemas/ProfileName"
           },
           "photos": {
             "default": [],
             "items": {
-              "$ref": "#/components/schemas/ProfileContent/$defs/PhotoAsset"
+              "$ref": "#/components/schemas/PhotoAsset"
             },
             "type": "array"
           }
@@ -6641,315 +2553,23 @@
         "type": "object"
       },
       "ProfileContentContent": {
-        "$defs": {
-          "BoundingBox": {
-            "properties": {
-              "bottomRight": {
-                "$ref": "#/components/schemas/ProfileContentContent/$defs/Coordinate",
-                "default": {
-                  "x": 0.0,
-                  "y": 0.0
-                }
-              },
-              "topLeft": {
-                "$ref": "#/components/schemas/ProfileContentContent/$defs/Coordinate",
-                "default": {
-                  "x": 0.0,
-                  "y": 0.0
-                }
-              }
-            },
-            "type": "object"
-          },
-          "Coordinate": {
-            "properties": {
-              "x": {
-                "default": 0.0,
-                "format": "double",
-                "type": "number"
-              },
-              "y": {
-                "default": 0.0,
-                "format": "double",
-                "type": "number"
-              }
-            },
-            "type": "object"
-          },
-          "Feedback": {
-            "properties": {
-              "detail": {
-                "type": "string"
-              },
-              "evaluation": {
-                "type": "string"
-              },
-              "feedbackToken": {
-                "type": "string"
-              }
-            },
-            "required": [
-              "evaluation",
-              "detail",
-              "feedbackToken"
-            ],
-            "type": "object"
-          },
-          "PhotoAsset": {
-            "properties": {
-              "boundingBox": {
-                "anyOf": [
-                  {
-                    "$ref": "#/components/schemas/ProfileContentContent/$defs/BoundingBox"
-                  },
-                  {
-                    "type": "null"
-                  }
-                ]
-              },
-              "caption": {
-                "type": [
-                  "string",
-                  "null"
-                ]
-              },
-              "cdnId": {
-                "type": [
-                  "string",
-                  "null"
-                ]
-              },
-              "contentId": {
-                "type": [
-                  "string",
-                  "null"
-                ]
-              },
-              "height": {
-                "format": "int32",
-                "type": [
-                  "integer",
-                  "null"
-                ]
-              },
-              "id": {
-                "type": [
-                  "string",
-                  "null"
-                ]
-              },
-              "location": {
-                "type": [
-                  "string",
-                  "null"
-                ]
-              },
-              "pHash": {
-                "type": [
-                  "string",
-                  "null"
-                ]
-              },
-              "promptId": {
-                "type": [
-                  "string",
-                  "null"
-                ]
-              },
-              "selfieVerified": {
-                "type": [
-                  "boolean",
-                  "null"
-                ]
-              },
-              "source": {
-                "type": [
-                  "string",
-                  "null"
-                ]
-              },
-              "sourceId": {
-                "type": [
-                  "string",
-                  "null"
-                ]
-              },
-              "url": {
-                "type": "string"
-              },
-              "videoUrl": {
-                "type": [
-                  "string",
-                  "null"
-                ]
-              },
-              "width": {
-                "format": "int32",
-                "type": [
-                  "integer",
-                  "null"
-                ]
-              }
-            },
-            "required": [
-              "url"
-            ],
-            "type": "object"
-          },
-          "ProfileAnswer": {
-            "properties": {
-              "cdnId": {
-                "type": [
-                  "string",
-                  "null"
-                ]
-              },
-              "content": {
-                "type": [
-                  "string",
-                  "null"
-                ]
-              },
-              "contentId": {
-                "type": [
-                  "string",
-                  "null"
-                ]
-              },
-              "feedback": {
-                "anyOf": [
-                  {
-                    "$ref": "#/components/schemas/ProfileContentContent/$defs/Feedback"
-                  },
-                  {
-                    "type": "null"
-                  }
-                ]
-              },
-              "position": {
-                "format": "int32",
-                "type": [
-                  "integer",
-                  "null"
-                ]
-              },
-              "promptId": {
-                "type": [
-                  "string",
-                  "null"
-                ]
-              },
-              "questionId": {
-                "type": [
-                  "string",
-                  "null"
-                ]
-              },
-              "response": {
-                "type": [
-                  "string",
-                  "null"
-                ]
-              },
-              "transcription": {
-                "type": [
-                  "string",
-                  "null"
-                ]
-              },
-              "transcriptionMetadata": true,
-              "type": {
-                "type": [
-                  "string",
-                  "null"
-                ]
-              },
-              "url": {
-                "type": [
-                  "string",
-                  "null"
-                ]
-              },
-              "waveform": {
-                "type": [
-                  "string",
-                  "null"
-                ]
-              }
-            },
-            "type": "object"
-          },
-          "PromptPoll": {
-            "properties": {
-              "contentId": {
-                "type": "string"
-              },
-              "options": {
-                "items": {
-                  "type": "string"
-                },
-                "type": "array"
-              },
-              "questionId": {
-                "type": "string"
-              }
-            },
-            "required": [
-              "contentId",
-              "questionId",
-              "options"
-            ],
-            "type": "object"
-          },
-          "VideoPrompt": {
-            "properties": {
-              "boundingBox": {
-                "$ref": "#/components/schemas/ProfileContentContent/$defs/BoundingBox"
-              },
-              "cdnId": {
-                "type": "string"
-              },
-              "contentId": {
-                "type": "string"
-              },
-              "questionId": {
-                "type": "string"
-              },
-              "thumbnailUrl": {
-                "type": "string"
-              },
-              "videoUrl": {
-                "type": "string"
-              }
-            },
-            "required": [
-              "contentId",
-              "questionId",
-              "thumbnailUrl",
-              "videoUrl",
-              "cdnId",
-              "boundingBox"
-            ],
-            "type": "object"
-          }
-        },
         "properties": {
           "answers": {
             "items": {
-              "$ref": "#/components/schemas/ProfileContentContent/$defs/ProfileAnswer"
+              "$ref": "#/components/schemas/ProfileAnswer"
             },
             "type": "array"
           },
           "photos": {
             "items": {
-              "$ref": "#/components/schemas/ProfileContentContent/$defs/PhotoAsset"
+              "$ref": "#/components/schemas/PhotoAsset"
             },
             "type": "array"
           },
           "promptPoll": {
             "anyOf": [
               {
-                "$ref": "#/components/schemas/ProfileContentContent/$defs/PromptPoll"
+                "$ref": "#/components/schemas/PromptPoll"
               },
               {
                 "type": "null"
@@ -6960,7 +2580,7 @@
           "videoPrompt": {
             "anyOf": [
               {
-                "$ref": "#/components/schemas/ProfileContentContent/$defs/VideoPrompt"
+                "$ref": "#/components/schemas/VideoPrompt"
               },
               {
                 "type": "null"
@@ -6977,344 +2597,9 @@
         "type": "object"
       },
       "ProfileContentFull": {
-        "$defs": {
-          "BoundingBox": {
-            "properties": {
-              "bottomRight": {
-                "$ref": "#/components/schemas/ProfileContentFull/$defs/Coordinate",
-                "default": {
-                  "x": 0.0,
-                  "y": 0.0
-                }
-              },
-              "topLeft": {
-                "$ref": "#/components/schemas/ProfileContentFull/$defs/Coordinate",
-                "default": {
-                  "x": 0.0,
-                  "y": 0.0
-                }
-              }
-            },
-            "type": "object"
-          },
-          "Coordinate": {
-            "properties": {
-              "x": {
-                "default": 0.0,
-                "format": "double",
-                "type": "number"
-              },
-              "y": {
-                "default": 0.0,
-                "format": "double",
-                "type": "number"
-              }
-            },
-            "type": "object"
-          },
-          "Feedback": {
-            "properties": {
-              "detail": {
-                "type": "string"
-              },
-              "evaluation": {
-                "type": "string"
-              },
-              "feedbackToken": {
-                "type": "string"
-              }
-            },
-            "required": [
-              "evaluation",
-              "detail",
-              "feedbackToken"
-            ],
-            "type": "object"
-          },
-          "PhotoAsset": {
-            "properties": {
-              "boundingBox": {
-                "anyOf": [
-                  {
-                    "$ref": "#/components/schemas/ProfileContentFull/$defs/BoundingBox"
-                  },
-                  {
-                    "type": "null"
-                  }
-                ]
-              },
-              "caption": {
-                "type": [
-                  "string",
-                  "null"
-                ]
-              },
-              "cdnId": {
-                "type": [
-                  "string",
-                  "null"
-                ]
-              },
-              "contentId": {
-                "type": [
-                  "string",
-                  "null"
-                ]
-              },
-              "height": {
-                "format": "int32",
-                "type": [
-                  "integer",
-                  "null"
-                ]
-              },
-              "id": {
-                "type": [
-                  "string",
-                  "null"
-                ]
-              },
-              "location": {
-                "type": [
-                  "string",
-                  "null"
-                ]
-              },
-              "pHash": {
-                "type": [
-                  "string",
-                  "null"
-                ]
-              },
-              "promptId": {
-                "type": [
-                  "string",
-                  "null"
-                ]
-              },
-              "selfieVerified": {
-                "type": [
-                  "boolean",
-                  "null"
-                ]
-              },
-              "source": {
-                "type": [
-                  "string",
-                  "null"
-                ]
-              },
-              "sourceId": {
-                "type": [
-                  "string",
-                  "null"
-                ]
-              },
-              "url": {
-                "type": "string"
-              },
-              "videoUrl": {
-                "type": [
-                  "string",
-                  "null"
-                ]
-              },
-              "width": {
-                "format": "int32",
-                "type": [
-                  "integer",
-                  "null"
-                ]
-              }
-            },
-            "required": [
-              "url"
-            ],
-            "type": "object"
-          },
-          "ProfileAnswer": {
-            "properties": {
-              "cdnId": {
-                "type": [
-                  "string",
-                  "null"
-                ]
-              },
-              "content": {
-                "type": [
-                  "string",
-                  "null"
-                ]
-              },
-              "contentId": {
-                "type": [
-                  "string",
-                  "null"
-                ]
-              },
-              "feedback": {
-                "anyOf": [
-                  {
-                    "$ref": "#/components/schemas/ProfileContentFull/$defs/Feedback"
-                  },
-                  {
-                    "type": "null"
-                  }
-                ]
-              },
-              "position": {
-                "format": "int32",
-                "type": [
-                  "integer",
-                  "null"
-                ]
-              },
-              "promptId": {
-                "type": [
-                  "string",
-                  "null"
-                ]
-              },
-              "questionId": {
-                "type": [
-                  "string",
-                  "null"
-                ]
-              },
-              "response": {
-                "type": [
-                  "string",
-                  "null"
-                ]
-              },
-              "transcription": {
-                "type": [
-                  "string",
-                  "null"
-                ]
-              },
-              "transcriptionMetadata": true,
-              "type": {
-                "type": [
-                  "string",
-                  "null"
-                ]
-              },
-              "url": {
-                "type": [
-                  "string",
-                  "null"
-                ]
-              },
-              "waveform": {
-                "type": [
-                  "string",
-                  "null"
-                ]
-              }
-            },
-            "type": "object"
-          },
-          "ProfileContentContent": {
-            "properties": {
-              "answers": {
-                "items": {
-                  "$ref": "#/components/schemas/ProfileContentFull/$defs/ProfileAnswer"
-                },
-                "type": "array"
-              },
-              "photos": {
-                "items": {
-                  "$ref": "#/components/schemas/ProfileContentFull/$defs/PhotoAsset"
-                },
-                "type": "array"
-              },
-              "promptPoll": {
-                "anyOf": [
-                  {
-                    "$ref": "#/components/schemas/ProfileContentFull/$defs/PromptPoll"
-                  },
-                  {
-                    "type": "null"
-                  }
-                ],
-                "default": null
-              },
-              "videoPrompt": {
-                "anyOf": [
-                  {
-                    "$ref": "#/components/schemas/ProfileContentFull/$defs/VideoPrompt"
-                  },
-                  {
-                    "type": "null"
-                  }
-                ],
-                "default": null
-              }
-            },
-            "required": [
-              "photos",
-              "answers"
-            ],
-            "type": "object"
-          },
-          "PromptPoll": {
-            "properties": {
-              "contentId": {
-                "type": "string"
-              },
-              "options": {
-                "items": {
-                  "type": "string"
-                },
-                "type": "array"
-              },
-              "questionId": {
-                "type": "string"
-              }
-            },
-            "required": [
-              "contentId",
-              "questionId",
-              "options"
-            ],
-            "type": "object"
-          },
-          "VideoPrompt": {
-            "properties": {
-              "boundingBox": {
-                "$ref": "#/components/schemas/ProfileContentFull/$defs/BoundingBox"
-              },
-              "cdnId": {
-                "type": "string"
-              },
-              "contentId": {
-                "type": "string"
-              },
-              "questionId": {
-                "type": "string"
-              },
-              "thumbnailUrl": {
-                "type": "string"
-              },
-              "videoUrl": {
-                "type": "string"
-              }
-            },
-            "required": [
-              "contentId",
-              "questionId",
-              "thumbnailUrl",
-              "videoUrl",
-              "cdnId",
-              "boundingBox"
-            ],
-            "type": "object"
-          }
-        },
         "properties": {
           "content": {
-            "$ref": "#/components/schemas/ProfileContentFull/$defs/ProfileContentContent"
+            "$ref": "#/components/schemas/ProfileContentContent"
           },
           "userId": {
             "type": "string"
@@ -7347,351 +2632,11 @@
         "type": "object"
       },
       "ProfileUpdate": {
-        "$defs": {
-          "ChildrenStatus": {
-            "properties": {
-              "value": {
-                "$ref": "#/components/schemas/ProfileUpdate/$defs/ChildrenStatusProfile"
-              },
-              "visible": {
-                "type": "boolean"
-              }
-            },
-            "required": [
-              "value",
-              "visible"
-            ],
-            "type": "object"
-          },
-          "ChildrenStatusProfile": {
-            "enum": [
-              "PreferNotToSay",
-              "No",
-              "Yes"
-            ],
-            "type": "string"
-          },
-          "DatingIntention": {
-            "properties": {
-              "value": {
-                "$ref": "#/components/schemas/ProfileUpdate/$defs/DatingIntentionProfile"
-              },
-              "visible": {
-                "type": "boolean"
-              }
-            },
-            "required": [
-              "value",
-              "visible"
-            ],
-            "type": "object"
-          },
-          "DatingIntentionProfile": {
-            "enum": [
-              "PreferNotToSay",
-              "LifePartner",
-              "LongTermRelationship",
-              "LongTermOpenToShort",
-              "ShortTermOpenToLong",
-              "ShortTermRelationship",
-              "FiguringOutTheirDatingGoals"
-            ],
-            "type": "string"
-          },
-          "DrinkingStatus": {
-            "properties": {
-              "value": {
-                "$ref": "#/components/schemas/ProfileUpdate/$defs/DrinkingStatusProfile"
-              },
-              "visible": {
-                "type": "boolean"
-              }
-            },
-            "required": [
-              "value",
-              "visible"
-            ],
-            "type": "object"
-          },
-          "DrinkingStatusProfile": {
-            "enum": [
-              "PreferNotToSay",
-              "No",
-              "Yes",
-              "Sometimes"
-            ],
-            "type": "string"
-          },
-          "DrugStatus": {
-            "properties": {
-              "value": {
-                "$ref": "#/components/schemas/ProfileUpdate/$defs/DrugStatusProfile"
-              },
-              "visible": {
-                "type": "boolean"
-              }
-            },
-            "required": [
-              "value",
-              "visible"
-            ],
-            "type": "object"
-          },
-          "DrugStatusProfile": {
-            "enum": [
-              "PreferNotToSay",
-              "No",
-              "Yes",
-              "Sometimes"
-            ],
-            "type": "string"
-          },
-          "EducationAttainedProfile": {
-            "enum": [
-              "PreferNotToSay",
-              "HighSchool",
-              "TradeSchool",
-              "InCollege",
-              "Undergraduate",
-              "InGradSchool",
-              "Graduate"
-            ],
-            "type": "string"
-          },
-          "Ethnicities": {
-            "properties": {
-              "value": {
-                "items": {
-                  "$ref": "#/components/schemas/ProfileUpdate/$defs/EthnicityProfile"
-                },
-                "type": "array"
-              },
-              "visible": {
-                "type": "boolean"
-              }
-            },
-            "required": [
-              "value",
-              "visible"
-            ],
-            "type": "object"
-          },
-          "EthnicityProfile": {
-            "enum": [
-              "PreferNotToSay",
-              "AmericanIndian",
-              "BlackAfrican",
-              "EastAsian",
-              "Hispanic",
-              "MiddleEastern",
-              "PacificIslander",
-              "SouthAsian",
-              "White",
-              "Other"
-            ],
-            "type": "string"
-          },
-          "GenderEnum": {
-            "enum": [
-              "Man",
-              "Woman",
-              "NonBinary"
-            ],
-            "type": "string"
-          },
-          "Hometown": {
-            "properties": {
-              "value": {
-                "type": "string"
-              },
-              "visible": {
-                "type": "boolean"
-              }
-            },
-            "required": [
-              "value",
-              "visible"
-            ],
-            "type": "object"
-          },
-          "LanguagesSpoken": {
-            "properties": {
-              "value": {
-                "items": {
-                  "format": "int32",
-                  "type": "integer"
-                },
-                "type": "array"
-              },
-              "visible": {
-                "type": "boolean"
-              }
-            },
-            "required": [
-              "value",
-              "visible"
-            ],
-            "type": "object"
-          },
-          "MarijuanaStatus": {
-            "properties": {
-              "value": {
-                "$ref": "#/components/schemas/ProfileUpdate/$defs/MarijuanaStatusProfile"
-              },
-              "visible": {
-                "type": "boolean"
-              }
-            },
-            "required": [
-              "value",
-              "visible"
-            ],
-            "type": "object"
-          },
-          "MarijuanaStatusProfile": {
-            "enum": [
-              "PreferNotToSay",
-              "No",
-              "Yes",
-              "Sometimes",
-              "NoPreference"
-            ],
-            "type": "string"
-          },
-          "Politics": {
-            "properties": {
-              "value": {
-                "$ref": "#/components/schemas/ProfileUpdate/$defs/PoliticsProfile"
-              },
-              "visible": {
-                "type": "boolean"
-              }
-            },
-            "required": [
-              "value",
-              "visible"
-            ],
-            "type": "object"
-          },
-          "PoliticsProfile": {
-            "enum": [
-              "PreferNotToSay",
-              "Liberal",
-              "Moderate",
-              "Conservative",
-              "NotPolitical",
-              "Other"
-            ],
-            "type": "string"
-          },
-          "RelationshipTypeIds": {
-            "properties": {
-              "value": {
-                "items": {
-                  "$ref": "#/components/schemas/ProfileUpdate/$defs/RelationshipTypeProfile"
-                },
-                "type": "array"
-              },
-              "visible": {
-                "type": "boolean"
-              }
-            },
-            "required": [
-              "value",
-              "visible"
-            ],
-            "type": "object"
-          },
-          "RelationshipTypeProfile": {
-            "enum": [
-              "PreferNotToSay",
-              "Monogamy",
-              "EthicalNonMonogamy",
-              "FiguringOutTheirRelationshipType"
-            ],
-            "type": "string"
-          },
-          "Religion": {
-            "properties": {
-              "value": {
-                "items": {
-                  "$ref": "#/components/schemas/ProfileUpdate/$defs/ReligionProfile"
-                },
-                "type": "array"
-              },
-              "visible": {
-                "type": "boolean"
-              }
-            },
-            "required": [
-              "value",
-              "visible"
-            ],
-            "type": "object"
-          },
-          "ReligionProfile": {
-            "enum": [
-              "PreferNotToSay",
-              "Spiritual",
-              "Catholic",
-              "Christian",
-              "Hindu",
-              "Jewish",
-              "Muslim",
-              "Buddhist",
-              "Agnostic",
-              "Atheist",
-              "Other",
-              "Sikh"
-            ],
-            "type": "string"
-          },
-          "SmokingStatus": {
-            "properties": {
-              "value": {
-                "$ref": "#/components/schemas/ProfileUpdate/$defs/SmokingStatusProfile"
-              },
-              "visible": {
-                "type": "boolean"
-              }
-            },
-            "required": [
-              "value",
-              "visible"
-            ],
-            "type": "object"
-          },
-          "SmokingStatusProfile": {
-            "enum": [
-              "PreferNotToSay",
-              "No",
-              "Yes",
-              "Sometimes"
-            ],
-            "type": "string"
-          },
-          "Zodiac": {
-            "properties": {
-              "value": {
-                "format": "int32",
-                "type": "integer"
-              },
-              "visible": {
-                "type": "boolean"
-              }
-            },
-            "required": [
-              "value",
-              "visible"
-            ],
-            "type": "object"
-          }
-        },
         "properties": {
           "children": {
             "anyOf": [
               {
-                "$ref": "#/components/schemas/ProfileUpdate/$defs/ChildrenStatus"
+                "$ref": "#/components/schemas/ChildrenStatus"
               },
               {
                 "type": "null"
@@ -7701,7 +2646,7 @@
           "datingIntention": {
             "anyOf": [
               {
-                "$ref": "#/components/schemas/ProfileUpdate/$defs/DatingIntention"
+                "$ref": "#/components/schemas/DatingIntention"
               },
               {
                 "type": "null"
@@ -7711,7 +2656,7 @@
           "drinking": {
             "anyOf": [
               {
-                "$ref": "#/components/schemas/ProfileUpdate/$defs/DrinkingStatus"
+                "$ref": "#/components/schemas/DrinkingStatus"
               },
               {
                 "type": "null"
@@ -7721,7 +2666,7 @@
           "drugs": {
             "anyOf": [
               {
-                "$ref": "#/components/schemas/ProfileUpdate/$defs/DrugStatus"
+                "$ref": "#/components/schemas/DrugStatus"
               },
               {
                 "type": "null"
@@ -7731,7 +2676,7 @@
           "educationAttained": {
             "anyOf": [
               {
-                "$ref": "#/components/schemas/ProfileUpdate/$defs/EducationAttainedProfile"
+                "$ref": "#/components/schemas/EducationAttainedProfile"
               },
               {
                 "type": "null"
@@ -7741,7 +2686,7 @@
           "ethnicities": {
             "anyOf": [
               {
-                "$ref": "#/components/schemas/ProfileUpdate/$defs/Ethnicities"
+                "$ref": "#/components/schemas/Ethnicities"
               },
               {
                 "type": "null"
@@ -7751,7 +2696,7 @@
           "genderId": {
             "anyOf": [
               {
-                "$ref": "#/components/schemas/ProfileUpdate/$defs/GenderEnum"
+                "$ref": "#/components/schemas/GenderEnum"
               },
               {
                 "type": "null"
@@ -7768,7 +2713,7 @@
           "hometown": {
             "anyOf": [
               {
-                "$ref": "#/components/schemas/ProfileUpdate/$defs/Hometown"
+                "$ref": "#/components/schemas/Hometown"
               },
               {
                 "type": "null"
@@ -7778,7 +2723,7 @@
           "languagesSpoken": {
             "anyOf": [
               {
-                "$ref": "#/components/schemas/ProfileUpdate/$defs/LanguagesSpoken"
+                "$ref": "#/components/schemas/LanguagesSpoken"
               },
               {
                 "type": "null"
@@ -7788,7 +2733,7 @@
           "marijuana": {
             "anyOf": [
               {
-                "$ref": "#/components/schemas/ProfileUpdate/$defs/MarijuanaStatus"
+                "$ref": "#/components/schemas/MarijuanaStatus"
               },
               {
                 "type": "null"
@@ -7798,7 +2743,7 @@
           "politics": {
             "anyOf": [
               {
-                "$ref": "#/components/schemas/ProfileUpdate/$defs/Politics"
+                "$ref": "#/components/schemas/Politics"
               },
               {
                 "type": "null"
@@ -7808,7 +2753,7 @@
           "relationshipTypeIds": {
             "anyOf": [
               {
-                "$ref": "#/components/schemas/ProfileUpdate/$defs/RelationshipTypeIds"
+                "$ref": "#/components/schemas/RelationshipTypeIds"
               },
               {
                 "type": "null"
@@ -7818,7 +2763,7 @@
           "religions": {
             "anyOf": [
               {
-                "$ref": "#/components/schemas/ProfileUpdate/$defs/Religion"
+                "$ref": "#/components/schemas/Religion"
               },
               {
                 "type": "null"
@@ -7828,7 +2773,7 @@
           "smoking": {
             "anyOf": [
               {
-                "$ref": "#/components/schemas/ProfileUpdate/$defs/SmokingStatus"
+                "$ref": "#/components/schemas/SmokingStatus"
               },
               {
                 "type": "null"
@@ -7838,7 +2783,7 @@
           "zodiac": {
             "anyOf": [
               {
-                "$ref": "#/components/schemas/ProfileUpdate/$defs/Zodiac"
+                "$ref": "#/components/schemas/Zodiac"
               },
               {
                 "type": "null"
@@ -7850,351 +2795,11 @@
         "type": "object"
       },
       "ProfileUpdateRequest": {
-        "$defs": {
-          "ChildrenStatus": {
-            "properties": {
-              "value": {
-                "$ref": "#/components/schemas/ProfileUpdateRequest/$defs/ChildrenStatusProfile"
-              },
-              "visible": {
-                "type": "boolean"
-              }
-            },
-            "required": [
-              "value",
-              "visible"
-            ],
-            "type": "object"
-          },
-          "ChildrenStatusProfile": {
-            "enum": [
-              "PreferNotToSay",
-              "No",
-              "Yes"
-            ],
-            "type": "string"
-          },
-          "DatingIntention": {
-            "properties": {
-              "value": {
-                "$ref": "#/components/schemas/ProfileUpdateRequest/$defs/DatingIntentionProfile"
-              },
-              "visible": {
-                "type": "boolean"
-              }
-            },
-            "required": [
-              "value",
-              "visible"
-            ],
-            "type": "object"
-          },
-          "DatingIntentionProfile": {
-            "enum": [
-              "PreferNotToSay",
-              "LifePartner",
-              "LongTermRelationship",
-              "LongTermOpenToShort",
-              "ShortTermOpenToLong",
-              "ShortTermRelationship",
-              "FiguringOutTheirDatingGoals"
-            ],
-            "type": "string"
-          },
-          "DrinkingStatus": {
-            "properties": {
-              "value": {
-                "$ref": "#/components/schemas/ProfileUpdateRequest/$defs/DrinkingStatusProfile"
-              },
-              "visible": {
-                "type": "boolean"
-              }
-            },
-            "required": [
-              "value",
-              "visible"
-            ],
-            "type": "object"
-          },
-          "DrinkingStatusProfile": {
-            "enum": [
-              "PreferNotToSay",
-              "No",
-              "Yes",
-              "Sometimes"
-            ],
-            "type": "string"
-          },
-          "DrugStatus": {
-            "properties": {
-              "value": {
-                "$ref": "#/components/schemas/ProfileUpdateRequest/$defs/DrugStatusProfile"
-              },
-              "visible": {
-                "type": "boolean"
-              }
-            },
-            "required": [
-              "value",
-              "visible"
-            ],
-            "type": "object"
-          },
-          "DrugStatusProfile": {
-            "enum": [
-              "PreferNotToSay",
-              "No",
-              "Yes",
-              "Sometimes"
-            ],
-            "type": "string"
-          },
-          "EducationAttainedProfile": {
-            "enum": [
-              "PreferNotToSay",
-              "HighSchool",
-              "TradeSchool",
-              "InCollege",
-              "Undergraduate",
-              "InGradSchool",
-              "Graduate"
-            ],
-            "type": "string"
-          },
-          "Ethnicities": {
-            "properties": {
-              "value": {
-                "items": {
-                  "$ref": "#/components/schemas/ProfileUpdateRequest/$defs/EthnicityProfile"
-                },
-                "type": "array"
-              },
-              "visible": {
-                "type": "boolean"
-              }
-            },
-            "required": [
-              "value",
-              "visible"
-            ],
-            "type": "object"
-          },
-          "EthnicityProfile": {
-            "enum": [
-              "PreferNotToSay",
-              "AmericanIndian",
-              "BlackAfrican",
-              "EastAsian",
-              "Hispanic",
-              "MiddleEastern",
-              "PacificIslander",
-              "SouthAsian",
-              "White",
-              "Other"
-            ],
-            "type": "string"
-          },
-          "GenderEnum": {
-            "enum": [
-              "Man",
-              "Woman",
-              "NonBinary"
-            ],
-            "type": "string"
-          },
-          "Hometown": {
-            "properties": {
-              "value": {
-                "type": "string"
-              },
-              "visible": {
-                "type": "boolean"
-              }
-            },
-            "required": [
-              "value",
-              "visible"
-            ],
-            "type": "object"
-          },
-          "LanguagesSpoken": {
-            "properties": {
-              "value": {
-                "items": {
-                  "format": "int32",
-                  "type": "integer"
-                },
-                "type": "array"
-              },
-              "visible": {
-                "type": "boolean"
-              }
-            },
-            "required": [
-              "value",
-              "visible"
-            ],
-            "type": "object"
-          },
-          "MarijuanaStatus": {
-            "properties": {
-              "value": {
-                "$ref": "#/components/schemas/ProfileUpdateRequest/$defs/MarijuanaStatusProfile"
-              },
-              "visible": {
-                "type": "boolean"
-              }
-            },
-            "required": [
-              "value",
-              "visible"
-            ],
-            "type": "object"
-          },
-          "MarijuanaStatusProfile": {
-            "enum": [
-              "PreferNotToSay",
-              "No",
-              "Yes",
-              "Sometimes",
-              "NoPreference"
-            ],
-            "type": "string"
-          },
-          "Politics": {
-            "properties": {
-              "value": {
-                "$ref": "#/components/schemas/ProfileUpdateRequest/$defs/PoliticsProfile"
-              },
-              "visible": {
-                "type": "boolean"
-              }
-            },
-            "required": [
-              "value",
-              "visible"
-            ],
-            "type": "object"
-          },
-          "PoliticsProfile": {
-            "enum": [
-              "PreferNotToSay",
-              "Liberal",
-              "Moderate",
-              "Conservative",
-              "NotPolitical",
-              "Other"
-            ],
-            "type": "string"
-          },
-          "RelationshipTypeIds": {
-            "properties": {
-              "value": {
-                "items": {
-                  "$ref": "#/components/schemas/ProfileUpdateRequest/$defs/RelationshipTypeProfile"
-                },
-                "type": "array"
-              },
-              "visible": {
-                "type": "boolean"
-              }
-            },
-            "required": [
-              "value",
-              "visible"
-            ],
-            "type": "object"
-          },
-          "RelationshipTypeProfile": {
-            "enum": [
-              "PreferNotToSay",
-              "Monogamy",
-              "EthicalNonMonogamy",
-              "FiguringOutTheirRelationshipType"
-            ],
-            "type": "string"
-          },
-          "Religion": {
-            "properties": {
-              "value": {
-                "items": {
-                  "$ref": "#/components/schemas/ProfileUpdateRequest/$defs/ReligionProfile"
-                },
-                "type": "array"
-              },
-              "visible": {
-                "type": "boolean"
-              }
-            },
-            "required": [
-              "value",
-              "visible"
-            ],
-            "type": "object"
-          },
-          "ReligionProfile": {
-            "enum": [
-              "PreferNotToSay",
-              "Spiritual",
-              "Catholic",
-              "Christian",
-              "Hindu",
-              "Jewish",
-              "Muslim",
-              "Buddhist",
-              "Agnostic",
-              "Atheist",
-              "Other",
-              "Sikh"
-            ],
-            "type": "string"
-          },
-          "SmokingStatus": {
-            "properties": {
-              "value": {
-                "$ref": "#/components/schemas/ProfileUpdateRequest/$defs/SmokingStatusProfile"
-              },
-              "visible": {
-                "type": "boolean"
-              }
-            },
-            "required": [
-              "value",
-              "visible"
-            ],
-            "type": "object"
-          },
-          "SmokingStatusProfile": {
-            "enum": [
-              "PreferNotToSay",
-              "No",
-              "Yes",
-              "Sometimes"
-            ],
-            "type": "string"
-          },
-          "Zodiac": {
-            "properties": {
-              "value": {
-                "format": "int32",
-                "type": "integer"
-              },
-              "visible": {
-                "type": "boolean"
-              }
-            },
-            "required": [
-              "value",
-              "visible"
-            ],
-            "type": "object"
-          }
-        },
         "properties": {
           "children": {
             "anyOf": [
               {
-                "$ref": "#/components/schemas/ProfileUpdateRequest/$defs/ChildrenStatus"
+                "$ref": "#/components/schemas/ChildrenStatus"
               },
               {
                 "type": "null"
@@ -8204,7 +2809,7 @@
           "datingIntention": {
             "anyOf": [
               {
-                "$ref": "#/components/schemas/ProfileUpdateRequest/$defs/DatingIntention"
+                "$ref": "#/components/schemas/DatingIntention"
               },
               {
                 "type": "null"
@@ -8214,7 +2819,7 @@
           "drinking": {
             "anyOf": [
               {
-                "$ref": "#/components/schemas/ProfileUpdateRequest/$defs/DrinkingStatus"
+                "$ref": "#/components/schemas/DrinkingStatus"
               },
               {
                 "type": "null"
@@ -8224,7 +2829,7 @@
           "drugs": {
             "anyOf": [
               {
-                "$ref": "#/components/schemas/ProfileUpdateRequest/$defs/DrugStatus"
+                "$ref": "#/components/schemas/DrugStatus"
               },
               {
                 "type": "null"
@@ -8234,7 +2839,7 @@
           "educationAttained": {
             "anyOf": [
               {
-                "$ref": "#/components/schemas/ProfileUpdateRequest/$defs/EducationAttainedProfile"
+                "$ref": "#/components/schemas/EducationAttainedProfile"
               },
               {
                 "type": "null"
@@ -8244,7 +2849,7 @@
           "ethnicities": {
             "anyOf": [
               {
-                "$ref": "#/components/schemas/ProfileUpdateRequest/$defs/Ethnicities"
+                "$ref": "#/components/schemas/Ethnicities"
               },
               {
                 "type": "null"
@@ -8254,7 +2859,7 @@
           "genderId": {
             "anyOf": [
               {
-                "$ref": "#/components/schemas/ProfileUpdateRequest/$defs/GenderEnum"
+                "$ref": "#/components/schemas/GenderEnum"
               },
               {
                 "type": "null"
@@ -8271,7 +2876,7 @@
           "hometown": {
             "anyOf": [
               {
-                "$ref": "#/components/schemas/ProfileUpdateRequest/$defs/Hometown"
+                "$ref": "#/components/schemas/Hometown"
               },
               {
                 "type": "null"
@@ -8281,7 +2886,7 @@
           "languagesSpoken": {
             "anyOf": [
               {
-                "$ref": "#/components/schemas/ProfileUpdateRequest/$defs/LanguagesSpoken"
+                "$ref": "#/components/schemas/LanguagesSpoken"
               },
               {
                 "type": "null"
@@ -8291,7 +2896,7 @@
           "marijuana": {
             "anyOf": [
               {
-                "$ref": "#/components/schemas/ProfileUpdateRequest/$defs/MarijuanaStatus"
+                "$ref": "#/components/schemas/MarijuanaStatus"
               },
               {
                 "type": "null"
@@ -8301,7 +2906,7 @@
           "politics": {
             "anyOf": [
               {
-                "$ref": "#/components/schemas/ProfileUpdateRequest/$defs/Politics"
+                "$ref": "#/components/schemas/Politics"
               },
               {
                 "type": "null"
@@ -8311,7 +2916,7 @@
           "relationshipTypeIds": {
             "anyOf": [
               {
-                "$ref": "#/components/schemas/ProfileUpdateRequest/$defs/RelationshipTypeIds"
+                "$ref": "#/components/schemas/RelationshipTypeIds"
               },
               {
                 "type": "null"
@@ -8321,7 +2926,7 @@
           "religions": {
             "anyOf": [
               {
-                "$ref": "#/components/schemas/ProfileUpdateRequest/$defs/Religion"
+                "$ref": "#/components/schemas/Religion"
               },
               {
                 "type": "null"
@@ -8331,7 +2936,7 @@
           "smoking": {
             "anyOf": [
               {
-                "$ref": "#/components/schemas/ProfileUpdateRequest/$defs/SmokingStatus"
+                "$ref": "#/components/schemas/SmokingStatus"
               },
               {
                 "type": "null"
@@ -8341,7 +2946,7 @@
           "zodiac": {
             "anyOf": [
               {
-                "$ref": "#/components/schemas/ProfileUpdateRequest/$defs/Zodiac"
+                "$ref": "#/components/schemas/Zodiac"
               },
               {
                 "type": "null"
@@ -8353,19 +2958,6 @@
         "type": "object"
       },
       "Prompt": {
-        "$defs": {
-          "ContentType": {
-            "enum": [
-              "text",
-              "media",
-              "audio",
-              "video",
-              "voice",
-              "poll"
-            ],
-            "type": "string"
-          }
-        },
         "properties": {
           "categories": {
             "default": [],
@@ -8377,7 +2969,7 @@
           "contentTypes": {
             "default": [],
             "items": {
-              "$ref": "#/components/schemas/Prompt/$defs/ContentType"
+              "$ref": "#/components/schemas/ContentType"
             },
             "type": "array"
           },
@@ -8460,93 +3052,16 @@
         "type": "object"
       },
       "PromptsResponse": {
-        "$defs": {
-          "ContentType": {
-            "enum": [
-              "text",
-              "media",
-              "audio",
-              "video",
-              "voice",
-              "poll"
-            ],
-            "type": "string"
-          },
-          "Prompt": {
-            "properties": {
-              "categories": {
-                "default": [],
-                "items": {
-                  "type": "string"
-                },
-                "type": "array"
-              },
-              "contentTypes": {
-                "default": [],
-                "items": {
-                  "$ref": "#/components/schemas/PromptsResponse/$defs/ContentType"
-                },
-                "type": "array"
-              },
-              "id": {
-                "type": "string"
-              },
-              "isNew": {
-                "type": "boolean"
-              },
-              "isSelectable": {
-                "type": "boolean"
-              },
-              "placeholder": {
-                "default": "",
-                "type": "string"
-              },
-              "prompt": {
-                "type": "string"
-              }
-            },
-            "required": [
-              "id",
-              "prompt",
-              "isSelectable",
-              "isNew"
-            ],
-            "type": "object"
-          },
-          "PromptCategory": {
-            "properties": {
-              "isNew": {
-                "type": "boolean"
-              },
-              "isVisible": {
-                "type": "boolean"
-              },
-              "name": {
-                "type": "string"
-              },
-              "slug": {
-                "type": "string"
-              }
-            },
-            "required": [
-              "name",
-              "slug",
-              "isVisible",
-              "isNew"
-            ],
-            "type": "object"
-          }
-        },
         "properties": {
           "categories": {
             "items": {
-              "$ref": "#/components/schemas/PromptsResponse/$defs/PromptCategory"
+              "$ref": "#/components/schemas/PromptCategory"
             },
             "type": "array"
           },
           "prompts": {
             "items": {
-              "$ref": "#/components/schemas/PromptsResponse/$defs/Prompt"
+              "$ref": "#/components/schemas/Prompt"
             },
             "type": "array"
           }
@@ -8558,6 +3073,25 @@
         "title": "PromptsResponse",
         "type": "object"
       },
+      "Pronouns": {
+        "properties": {
+          "value": {
+            "items": {
+              "format": "int32",
+              "type": "integer"
+            },
+            "type": "array"
+          },
+          "visible": {
+            "type": "boolean"
+          }
+        },
+        "required": [
+          "value",
+          "visible"
+        ],
+        "type": "object"
+      },
       "PublicContentResponse": {
         "items": {
           "$ref": "#/components/schemas/ProfileContentFull"
@@ -8565,89 +3099,6 @@
         "type": "array"
       },
       "PublicProfile": {
-        "$defs": {
-          "EducationAttainedProfile": {
-            "enum": [
-              "PreferNotToSay",
-              "HighSchool",
-              "TradeSchool",
-              "InCollege",
-              "Undergraduate",
-              "InGradSchool",
-              "Graduate"
-            ],
-            "type": "string"
-          },
-          "GenderEnum": {
-            "enum": [
-              "Man",
-              "Woman",
-              "NonBinary"
-            ],
-            "type": "string"
-          },
-          "Location": {
-            "properties": {
-              "adminArea1Long": {
-                "type": [
-                  "string",
-                  "null"
-                ]
-              },
-              "adminArea1Short": {
-                "type": [
-                  "string",
-                  "null"
-                ]
-              },
-              "adminArea2": {
-                "type": [
-                  "string",
-                  "null"
-                ]
-              },
-              "countryShort": {
-                "type": [
-                  "string",
-                  "null"
-                ]
-              },
-              "latitude": {
-                "format": "double",
-                "type": [
-                  "number",
-                  "null"
-                ]
-              },
-              "longitude": {
-                "format": "double",
-                "type": [
-                  "number",
-                  "null"
-                ]
-              },
-              "metroArea": {
-                "type": [
-                  "string",
-                  "null"
-                ]
-              },
-              "metroAreaV2": {
-                "type": [
-                  "string",
-                  "null"
-                ]
-              },
-              "name": {
-                "type": "string"
-              }
-            },
-            "required": [
-              "name"
-            ],
-            "type": "object"
-          }
-        },
         "properties": {
           "age": {
             "format": "int32",
@@ -8712,7 +3163,7 @@
           "educationAttained": {
             "anyOf": [
               {
-                "$ref": "#/components/schemas/PublicProfile/$defs/EducationAttainedProfile"
+                "$ref": "#/components/schemas/EducationAttainedProfile"
               },
               {
                 "type": "null"
@@ -8775,7 +3226,7 @@
           "genderId": {
             "anyOf": [
               {
-                "$ref": "#/components/schemas/PublicProfile/$defs/GenderEnum"
+                "$ref": "#/components/schemas/GenderEnum"
               },
               {
                 "type": "null"
@@ -8838,7 +3289,7 @@
             ]
           },
           "location": {
-            "$ref": "#/components/schemas/PublicProfile/$defs/Location"
+            "$ref": "#/components/schemas/Location"
           },
           "marijuana": {
             "format": "int32",
@@ -8957,394 +3408,9 @@
         "type": "array"
       },
       "PublicUserProfile": {
-        "$defs": {
-          "EducationAttainedProfile": {
-            "enum": [
-              "PreferNotToSay",
-              "HighSchool",
-              "TradeSchool",
-              "InCollege",
-              "Undergraduate",
-              "InGradSchool",
-              "Graduate"
-            ],
-            "type": "string"
-          },
-          "GenderEnum": {
-            "enum": [
-              "Man",
-              "Woman",
-              "NonBinary"
-            ],
-            "type": "string"
-          },
-          "Location": {
-            "properties": {
-              "adminArea1Long": {
-                "type": [
-                  "string",
-                  "null"
-                ]
-              },
-              "adminArea1Short": {
-                "type": [
-                  "string",
-                  "null"
-                ]
-              },
-              "adminArea2": {
-                "type": [
-                  "string",
-                  "null"
-                ]
-              },
-              "countryShort": {
-                "type": [
-                  "string",
-                  "null"
-                ]
-              },
-              "latitude": {
-                "format": "double",
-                "type": [
-                  "number",
-                  "null"
-                ]
-              },
-              "longitude": {
-                "format": "double",
-                "type": [
-                  "number",
-                  "null"
-                ]
-              },
-              "metroArea": {
-                "type": [
-                  "string",
-                  "null"
-                ]
-              },
-              "metroAreaV2": {
-                "type": [
-                  "string",
-                  "null"
-                ]
-              },
-              "name": {
-                "type": "string"
-              }
-            },
-            "required": [
-              "name"
-            ],
-            "type": "object"
-          },
-          "PublicProfile": {
-            "properties": {
-              "age": {
-                "format": "int32",
-                "type": [
-                  "integer",
-                  "null"
-                ]
-              },
-              "birthday": {
-                "type": [
-                  "string",
-                  "null"
-                ]
-              },
-              "children": {
-                "format": "int32",
-                "type": [
-                  "integer",
-                  "null"
-                ]
-              },
-              "covidVax": {
-                "format": "int32",
-                "type": [
-                  "integer",
-                  "null"
-                ]
-              },
-              "datingIntention": {
-                "format": "int32",
-                "type": [
-                  "integer",
-                  "null"
-                ]
-              },
-              "datingIntentionText": {
-                "type": [
-                  "string",
-                  "null"
-                ]
-              },
-              "didJustJoin": {
-                "type": [
-                  "boolean",
-                  "null"
-                ]
-              },
-              "drinking": {
-                "format": "int32",
-                "type": [
-                  "integer",
-                  "null"
-                ]
-              },
-              "drugs": {
-                "format": "int32",
-                "type": [
-                  "integer",
-                  "null"
-                ]
-              },
-              "educationAttained": {
-                "anyOf": [
-                  {
-                    "$ref": "#/components/schemas/PublicUserProfile/$defs/EducationAttainedProfile"
-                  },
-                  {
-                    "type": "null"
-                  }
-                ]
-              },
-              "educations": {
-                "items": {
-                  "type": "string"
-                },
-                "type": [
-                  "array",
-                  "null"
-                ]
-              },
-              "email": {
-                "type": [
-                  "string",
-                  "null"
-                ]
-              },
-              "emailVerified": {
-                "type": [
-                  "boolean",
-                  "null"
-                ]
-              },
-              "ethnicities": {
-                "items": {
-                  "format": "int32",
-                  "type": "integer"
-                },
-                "type": [
-                  "array",
-                  "null"
-                ]
-              },
-              "ethnicitiesText": {
-                "type": [
-                  "string",
-                  "null"
-                ]
-              },
-              "familyPlans": {
-                "format": "int32",
-                "type": [
-                  "integer",
-                  "null"
-                ]
-              },
-              "firstCompletedDate": {
-                "type": [
-                  "string",
-                  "null"
-                ]
-              },
-              "firstName": {
-                "type": "string"
-              },
-              "genderId": {
-                "anyOf": [
-                  {
-                    "$ref": "#/components/schemas/PublicUserProfile/$defs/GenderEnum"
-                  },
-                  {
-                    "type": "null"
-                  }
-                ]
-              },
-              "genderIdentity": {
-                "type": [
-                  "string",
-                  "null"
-                ]
-              },
-              "genderIdentityId": {
-                "format": "int32",
-                "type": [
-                  "integer",
-                  "null"
-                ]
-              },
-              "height": {
-                "format": "int32",
-                "type": [
-                  "integer",
-                  "null"
-                ]
-              },
-              "hometown": {
-                "type": [
-                  "string",
-                  "null"
-                ]
-              },
-              "jobTitle": {
-                "type": [
-                  "string",
-                  "null"
-                ]
-              },
-              "languagesSpoken": {
-                "items": {
-                  "format": "int32",
-                  "type": "integer"
-                },
-                "type": [
-                  "array",
-                  "null"
-                ]
-              },
-              "lastActiveStatusId": {
-                "format": "int32",
-                "type": [
-                  "integer",
-                  "null"
-                ]
-              },
-              "lastName": {
-                "type": [
-                  "string",
-                  "null"
-                ]
-              },
-              "location": {
-                "$ref": "#/components/schemas/PublicUserProfile/$defs/Location"
-              },
-              "marijuana": {
-                "format": "int32",
-                "type": [
-                  "integer",
-                  "null"
-                ]
-              },
-              "pets": {
-                "items": {
-                  "format": "int32",
-                  "type": "integer"
-                },
-                "type": [
-                  "array",
-                  "null"
-                ]
-              },
-              "phone": {
-                "type": [
-                  "string",
-                  "null"
-                ]
-              },
-              "politics": {
-                "format": "int32",
-                "type": [
-                  "integer",
-                  "null"
-                ]
-              },
-              "pronouns": {
-                "items": {
-                  "format": "int32",
-                  "type": "integer"
-                },
-                "type": [
-                  "array",
-                  "null"
-                ]
-              },
-              "relationshipTypeIds": {
-                "items": {
-                  "format": "int32",
-                  "type": "integer"
-                },
-                "type": [
-                  "array",
-                  "null"
-                ]
-              },
-              "relationshipTypesText": {
-                "type": [
-                  "string",
-                  "null"
-                ]
-              },
-              "religions": {
-                "items": {
-                  "format": "int32",
-                  "type": "integer"
-                },
-                "type": [
-                  "array",
-                  "null"
-                ]
-              },
-              "selfieVerified": {
-                "type": [
-                  "boolean",
-                  "null"
-                ]
-              },
-              "sexualOrientations": {
-                "items": {
-                  "format": "int32",
-                  "type": "integer"
-                },
-                "type": [
-                  "array",
-                  "null"
-                ]
-              },
-              "smoking": {
-                "format": "int32",
-                "type": [
-                  "integer",
-                  "null"
-                ]
-              },
-              "works": {
-                "type": [
-                  "string",
-                  "null"
-                ]
-              },
-              "zodiac": {
-                "format": "int32",
-                "type": [
-                  "integer",
-                  "null"
-                ]
-              }
-            },
-            "required": [
-              "firstName",
-              "location"
-            ],
-            "type": "object"
-          }
-        },
         "properties": {
           "profile": {
-            "$ref": "#/components/schemas/PublicUserProfile/$defs/PublicProfile"
+            "$ref": "#/components/schemas/PublicProfile"
           },
           "userId": {
             "type": "string"
@@ -9392,81 +3458,6 @@
         "type": "object"
       },
       "RateInput": {
-        "$defs": {
-          "BoundingBox": {
-            "properties": {
-              "bottomRight": {
-                "$ref": "#/components/schemas/RateInput/$defs/Coordinate",
-                "default": {
-                  "x": 0.0,
-                  "y": 0.0
-                }
-              },
-              "topLeft": {
-                "$ref": "#/components/schemas/RateInput/$defs/Coordinate",
-                "default": {
-                  "x": 0.0,
-                  "y": 0.0
-                }
-              }
-            },
-            "type": "object"
-          },
-          "Coordinate": {
-            "properties": {
-              "x": {
-                "default": 0.0,
-                "format": "double",
-                "type": "number"
-              },
-              "y": {
-                "default": 0.0,
-                "format": "double",
-                "type": "number"
-              }
-            },
-            "type": "object"
-          },
-          "PhotoAssetInput": {
-            "properties": {
-              "boundingBox": {
-                "anyOf": [
-                  {
-                    "$ref": "#/components/schemas/RateInput/$defs/BoundingBox"
-                  },
-                  {
-                    "type": "null"
-                  }
-                ]
-              },
-              "cdnId": {
-                "type": [
-                  "string",
-                  "null"
-                ]
-              },
-              "contentId": {
-                "type": [
-                  "string",
-                  "null"
-                ]
-              },
-              "selfieVerified": {
-                "type": [
-                  "boolean",
-                  "null"
-                ]
-              },
-              "url": {
-                "type": "string"
-              }
-            },
-            "required": [
-              "url"
-            ],
-            "type": "object"
-          }
-        },
         "properties": {
           "answerText": {
             "default": null,
@@ -9499,7 +3490,7 @@
           "photo": {
             "anyOf": [
               {
-                "$ref": "#/components/schemas/RateInput/$defs/PhotoAssetInput"
+                "$ref": "#/components/schemas/PhotoAssetInput"
               },
               {
                 "type": "null"
@@ -9536,26 +3527,11 @@
         "type": "object"
       },
       "RatePayload": {
-        "$defs": {
-          "RateContentPayload": {
-            "properties": {
-              "comment": {
-                "type": [
-                  "string",
-                  "null"
-                ]
-              },
-              "photo": true,
-              "prompt": true
-            },
-            "type": "object"
-          }
-        },
         "properties": {
           "content": {
             "anyOf": [
               {
-                "$ref": "#/components/schemas/RatePayload/$defs/RateContentPayload"
+                "$ref": "#/components/schemas/RateContentPayload"
               },
               {
                 "type": "null"
@@ -9653,33 +3629,11 @@
         "type": "object"
       },
       "RateRespondResponse": {
-        "$defs": {
-          "LikeLimit": {
-            "properties": {
-              "likes": {
-                "format": "int32",
-                "type": "integer"
-              },
-              "superlikes": {
-                "default": null,
-                "format": "int32",
-                "type": [
-                  "integer",
-                  "null"
-                ]
-              }
-            },
-            "required": [
-              "likes"
-            ],
-            "type": "object"
-          }
-        },
         "properties": {
           "limit": {
             "anyOf": [
               {
-                "$ref": "#/components/schemas/RateRespondResponse/$defs/LikeLimit"
+                "$ref": "#/components/schemas/LikeLimit"
               },
               {
                 "type": "null"
@@ -9720,48 +3674,6 @@
         "type": "object"
       },
       "RecommendationsFeed": {
-        "$defs": {
-          "RecommendationSubject": {
-            "properties": {
-              "origin": {
-                "default": null,
-                "type": [
-                  "string",
-                  "null"
-                ]
-              },
-              "ratingToken": {
-                "type": "string"
-              },
-              "subjectId": {
-                "type": "string"
-              }
-            },
-            "required": [
-              "subjectId",
-              "ratingToken"
-            ],
-            "type": "object"
-          },
-          "RecommendationsPreview": {
-            "properties": {
-              "permission": {
-                "type": "string"
-              },
-              "subjects": {
-                "items": {
-                  "$ref": "#/components/schemas/RecommendationsFeed/$defs/RecommendationSubject"
-                },
-                "type": "array"
-              }
-            },
-            "required": [
-              "subjects",
-              "permission"
-            ],
-            "type": "object"
-          }
-        },
         "properties": {
           "id": {
             "format": "int32",
@@ -9780,7 +3692,7 @@
           "preview": {
             "anyOf": [
               {
-                "$ref": "#/components/schemas/RecommendationsFeed/$defs/RecommendationsPreview"
+                "$ref": "#/components/schemas/RecommendationsPreview"
               },
               {
                 "type": "null"
@@ -9790,7 +3702,7 @@
           },
           "subjects": {
             "items": {
-              "$ref": "#/components/schemas/RecommendationsFeed/$defs/RecommendationSubject"
+              "$ref": "#/components/schemas/RecommendationSubject"
             },
             "type": "array"
           }
@@ -9804,37 +3716,13 @@
         "type": "object"
       },
       "RecommendationsPreview": {
-        "$defs": {
-          "RecommendationSubject": {
-            "properties": {
-              "origin": {
-                "default": null,
-                "type": [
-                  "string",
-                  "null"
-                ]
-              },
-              "ratingToken": {
-                "type": "string"
-              },
-              "subjectId": {
-                "type": "string"
-              }
-            },
-            "required": [
-              "subjectId",
-              "ratingToken"
-            ],
-            "type": "object"
-          }
-        },
         "properties": {
           "permission": {
             "type": "string"
           },
           "subjects": {
             "items": {
-              "$ref": "#/components/schemas/RecommendationsPreview/$defs/RecommendationSubject"
+              "$ref": "#/components/schemas/RecommendationSubject"
             },
             "type": "array"
           }
@@ -9862,113 +3750,11 @@
         "type": "object"
       },
       "RecommendationsResponse": {
-        "$defs": {
-          "ActivePill": {
-            "properties": {
-              "id": {
-                "type": "string"
-              },
-              "permission": {
-                "type": "string"
-              },
-              "pillType": {
-                "type": "string"
-              }
-            },
-            "required": [
-              "pillType",
-              "permission",
-              "id"
-            ],
-            "type": "object"
-          },
-          "RecommendationSubject": {
-            "properties": {
-              "origin": {
-                "default": null,
-                "type": [
-                  "string",
-                  "null"
-                ]
-              },
-              "ratingToken": {
-                "type": "string"
-              },
-              "subjectId": {
-                "type": "string"
-              }
-            },
-            "required": [
-              "subjectId",
-              "ratingToken"
-            ],
-            "type": "object"
-          },
-          "RecommendationsFeed": {
-            "properties": {
-              "id": {
-                "format": "int32",
-                "type": "integer"
-              },
-              "origin": {
-                "type": "string"
-              },
-              "permission": {
-                "default": null,
-                "type": [
-                  "string",
-                  "null"
-                ]
-              },
-              "preview": {
-                "anyOf": [
-                  {
-                    "$ref": "#/components/schemas/RecommendationsResponse/$defs/RecommendationsPreview"
-                  },
-                  {
-                    "type": "null"
-                  }
-                ],
-                "default": null
-              },
-              "subjects": {
-                "items": {
-                  "$ref": "#/components/schemas/RecommendationsResponse/$defs/RecommendationSubject"
-                },
-                "type": "array"
-              }
-            },
-            "required": [
-              "id",
-              "origin",
-              "subjects"
-            ],
-            "type": "object"
-          },
-          "RecommendationsPreview": {
-            "properties": {
-              "permission": {
-                "type": "string"
-              },
-              "subjects": {
-                "items": {
-                  "$ref": "#/components/schemas/RecommendationsResponse/$defs/RecommendationSubject"
-                },
-                "type": "array"
-              }
-            },
-            "required": [
-              "subjects",
-              "permission"
-            ],
-            "type": "object"
-          }
-        },
         "properties": {
           "activePills": {
             "default": null,
             "items": {
-              "$ref": "#/components/schemas/RecommendationsResponse/$defs/ActivePill"
+              "$ref": "#/components/schemas/ActivePill"
             },
             "type": [
               "array",
@@ -9980,7 +3766,7 @@
           },
           "feeds": {
             "items": {
-              "$ref": "#/components/schemas/RecommendationsResponse/$defs/RecommendationsFeed"
+              "$ref": "#/components/schemas/RecommendationsFeed"
             },
             "type": "array"
           }
@@ -10005,341 +3791,98 @@
         "title": "RecsV2Params",
         "type": "object"
       },
-      "SelfContentResponse": {
-        "$defs": {
-          "BoundingBox": {
-            "properties": {
-              "bottomRight": {
-                "$ref": "#/components/schemas/SelfContentResponse/$defs/Coordinate",
-                "default": {
-                  "x": 0.0,
-                  "y": 0.0
-                }
-              },
-              "topLeft": {
-                "$ref": "#/components/schemas/SelfContentResponse/$defs/Coordinate",
-                "default": {
-                  "x": 0.0,
-                  "y": 0.0
-                }
-              }
+      "RelationshipTypeIds": {
+        "properties": {
+          "value": {
+            "items": {
+              "$ref": "#/components/schemas/RelationshipTypeProfile"
             },
-            "type": "object"
+            "type": "array"
           },
-          "ContentData": {
-            "properties": {
-              "answers": {
-                "default": [],
-                "items": {
-                  "$ref": "#/components/schemas/SelfContentResponse/$defs/ProfileAnswer"
-                },
-                "type": "array"
-              },
-              "photos": {
-                "default": [],
-                "items": {
-                  "$ref": "#/components/schemas/SelfContentResponse/$defs/PhotoAsset"
-                },
-                "type": "array"
-              },
-              "promptPoll": {
-                "anyOf": [
-                  {
-                    "$ref": "#/components/schemas/SelfContentResponse/$defs/PromptPoll"
-                  },
-                  {
-                    "type": "null"
-                  }
-                ]
-              },
-              "videoPrompt": {
-                "anyOf": [
-                  {
-                    "$ref": "#/components/schemas/SelfContentResponse/$defs/VideoPrompt"
-                  },
-                  {
-                    "type": "null"
-                  }
-                ]
-              }
-            },
-            "type": "object"
-          },
-          "Coordinate": {
-            "properties": {
-              "x": {
-                "default": 0.0,
-                "format": "double",
-                "type": "number"
-              },
-              "y": {
-                "default": 0.0,
-                "format": "double",
-                "type": "number"
-              }
-            },
-            "type": "object"
-          },
-          "Feedback": {
-            "properties": {
-              "detail": {
-                "type": "string"
-              },
-              "evaluation": {
-                "type": "string"
-              },
-              "feedbackToken": {
-                "type": "string"
-              }
-            },
-            "required": [
-              "evaluation",
-              "detail",
-              "feedbackToken"
-            ],
-            "type": "object"
-          },
-          "PhotoAsset": {
-            "properties": {
-              "boundingBox": {
-                "anyOf": [
-                  {
-                    "$ref": "#/components/schemas/SelfContentResponse/$defs/BoundingBox"
-                  },
-                  {
-                    "type": "null"
-                  }
-                ]
-              },
-              "caption": {
-                "type": [
-                  "string",
-                  "null"
-                ]
-              },
-              "cdnId": {
-                "type": [
-                  "string",
-                  "null"
-                ]
-              },
-              "contentId": {
-                "type": [
-                  "string",
-                  "null"
-                ]
-              },
-              "height": {
-                "format": "int32",
-                "type": [
-                  "integer",
-                  "null"
-                ]
-              },
-              "id": {
-                "type": [
-                  "string",
-                  "null"
-                ]
-              },
-              "location": {
-                "type": [
-                  "string",
-                  "null"
-                ]
-              },
-              "pHash": {
-                "type": [
-                  "string",
-                  "null"
-                ]
-              },
-              "promptId": {
-                "type": [
-                  "string",
-                  "null"
-                ]
-              },
-              "selfieVerified": {
-                "type": [
-                  "boolean",
-                  "null"
-                ]
-              },
-              "source": {
-                "type": [
-                  "string",
-                  "null"
-                ]
-              },
-              "sourceId": {
-                "type": [
-                  "string",
-                  "null"
-                ]
-              },
-              "url": {
-                "type": "string"
-              },
-              "videoUrl": {
-                "type": [
-                  "string",
-                  "null"
-                ]
-              },
-              "width": {
-                "format": "int32",
-                "type": [
-                  "integer",
-                  "null"
-                ]
-              }
-            },
-            "required": [
-              "url"
-            ],
-            "type": "object"
-          },
-          "ProfileAnswer": {
-            "properties": {
-              "cdnId": {
-                "type": [
-                  "string",
-                  "null"
-                ]
-              },
-              "content": {
-                "type": [
-                  "string",
-                  "null"
-                ]
-              },
-              "contentId": {
-                "type": [
-                  "string",
-                  "null"
-                ]
-              },
-              "feedback": {
-                "anyOf": [
-                  {
-                    "$ref": "#/components/schemas/SelfContentResponse/$defs/Feedback"
-                  },
-                  {
-                    "type": "null"
-                  }
-                ]
-              },
-              "position": {
-                "format": "int32",
-                "type": [
-                  "integer",
-                  "null"
-                ]
-              },
-              "promptId": {
-                "type": [
-                  "string",
-                  "null"
-                ]
-              },
-              "questionId": {
-                "type": [
-                  "string",
-                  "null"
-                ]
-              },
-              "response": {
-                "type": [
-                  "string",
-                  "null"
-                ]
-              },
-              "transcription": {
-                "type": [
-                  "string",
-                  "null"
-                ]
-              },
-              "transcriptionMetadata": true,
-              "type": {
-                "type": [
-                  "string",
-                  "null"
-                ]
-              },
-              "url": {
-                "type": [
-                  "string",
-                  "null"
-                ]
-              },
-              "waveform": {
-                "type": [
-                  "string",
-                  "null"
-                ]
-              }
-            },
-            "type": "object"
-          },
-          "PromptPoll": {
-            "properties": {
-              "contentId": {
-                "type": "string"
-              },
-              "options": {
-                "items": {
-                  "type": "string"
-                },
-                "type": "array"
-              },
-              "questionId": {
-                "type": "string"
-              }
-            },
-            "required": [
-              "contentId",
-              "questionId",
-              "options"
-            ],
-            "type": "object"
-          },
-          "VideoPrompt": {
-            "properties": {
-              "boundingBox": {
-                "$ref": "#/components/schemas/SelfContentResponse/$defs/BoundingBox"
-              },
-              "cdnId": {
-                "type": "string"
-              },
-              "contentId": {
-                "type": "string"
-              },
-              "questionId": {
-                "type": "string"
-              },
-              "thumbnailUrl": {
-                "type": "string"
-              },
-              "videoUrl": {
-                "type": "string"
-              }
-            },
-            "required": [
-              "contentId",
-              "questionId",
-              "thumbnailUrl",
-              "videoUrl",
-              "cdnId",
-              "boundingBox"
-            ],
-            "type": "object"
+          "visible": {
+            "type": "boolean"
           }
         },
+        "required": [
+          "value",
+          "visible"
+        ],
+        "type": "object"
+      },
+      "RelationshipTypePreference": {
+        "enum": [
+          "OpenToAll",
+          "Monogamy",
+          "EthicalNonMonogamy",
+          "FiguringOutTheirRelationshipType"
+        ],
+        "type": "string"
+      },
+      "RelationshipTypeProfile": {
+        "enum": [
+          "PreferNotToSay",
+          "Monogamy",
+          "EthicalNonMonogamy",
+          "FiguringOutTheirRelationshipType"
+        ],
+        "type": "string"
+      },
+      "Religion": {
+        "properties": {
+          "value": {
+            "items": {
+              "$ref": "#/components/schemas/ReligionProfile"
+            },
+            "type": "array"
+          },
+          "visible": {
+            "type": "boolean"
+          }
+        },
+        "required": [
+          "value",
+          "visible"
+        ],
+        "type": "object"
+      },
+      "ReligionPreference": {
+        "enum": [
+          "OpenToAll",
+          "Spiritual",
+          "Catholic",
+          "Christian",
+          "Hindu",
+          "Jewish",
+          "Muslim",
+          "Buddhist",
+          "Agnostic",
+          "Atheist",
+          "Other",
+          "Sikh"
+        ],
+        "type": "string"
+      },
+      "ReligionProfile": {
+        "enum": [
+          "PreferNotToSay",
+          "Spiritual",
+          "Catholic",
+          "Christian",
+          "Hindu",
+          "Jewish",
+          "Muslim",
+          "Buddhist",
+          "Agnostic",
+          "Atheist",
+          "Other",
+          "Sikh"
+        ],
+        "type": "string"
+      },
+      "SelfContentResponse": {
         "properties": {
           "content": {
-            "$ref": "#/components/schemas/SelfContentResponse/$defs/ContentData"
+            "$ref": "#/components/schemas/ContentData"
           }
         },
         "required": [
@@ -10349,1140 +3892,6 @@
         "type": "object"
       },
       "SelfProfileResponse": {
-        "$defs": {
-          "BoundingBox": {
-            "properties": {
-              "bottomRight": {
-                "$ref": "#/components/schemas/SelfProfileResponse/$defs/Coordinate",
-                "default": {
-                  "x": 0.0,
-                  "y": 0.0
-                }
-              },
-              "topLeft": {
-                "$ref": "#/components/schemas/SelfProfileResponse/$defs/Coordinate",
-                "default": {
-                  "x": 0.0,
-                  "y": 0.0
-                }
-              }
-            },
-            "type": "object"
-          },
-          "ChildrenStatus": {
-            "properties": {
-              "value": {
-                "$ref": "#/components/schemas/SelfProfileResponse/$defs/ChildrenStatusProfile"
-              },
-              "visible": {
-                "type": "boolean"
-              }
-            },
-            "required": [
-              "value",
-              "visible"
-            ],
-            "type": "object"
-          },
-          "ChildrenStatusProfile": {
-            "enum": [
-              "PreferNotToSay",
-              "No",
-              "Yes"
-            ],
-            "type": "string"
-          },
-          "Coordinate": {
-            "properties": {
-              "x": {
-                "default": 0.0,
-                "format": "double",
-                "type": "number"
-              },
-              "y": {
-                "default": 0.0,
-                "format": "double",
-                "type": "number"
-              }
-            },
-            "type": "object"
-          },
-          "DatingIntention": {
-            "properties": {
-              "value": {
-                "$ref": "#/components/schemas/SelfProfileResponse/$defs/DatingIntentionProfile"
-              },
-              "visible": {
-                "type": "boolean"
-              }
-            },
-            "required": [
-              "value",
-              "visible"
-            ],
-            "type": "object"
-          },
-          "DatingIntentionProfile": {
-            "enum": [
-              "PreferNotToSay",
-              "LifePartner",
-              "LongTermRelationship",
-              "LongTermOpenToShort",
-              "ShortTermOpenToLong",
-              "ShortTermRelationship",
-              "FiguringOutTheirDatingGoals"
-            ],
-            "type": "string"
-          },
-          "DrinkingStatus": {
-            "properties": {
-              "value": {
-                "$ref": "#/components/schemas/SelfProfileResponse/$defs/DrinkingStatusProfile"
-              },
-              "visible": {
-                "type": "boolean"
-              }
-            },
-            "required": [
-              "value",
-              "visible"
-            ],
-            "type": "object"
-          },
-          "DrinkingStatusProfile": {
-            "enum": [
-              "PreferNotToSay",
-              "No",
-              "Yes",
-              "Sometimes"
-            ],
-            "type": "string"
-          },
-          "DrugStatus": {
-            "properties": {
-              "value": {
-                "$ref": "#/components/schemas/SelfProfileResponse/$defs/DrugStatusProfile"
-              },
-              "visible": {
-                "type": "boolean"
-              }
-            },
-            "required": [
-              "value",
-              "visible"
-            ],
-            "type": "object"
-          },
-          "DrugStatusProfile": {
-            "enum": [
-              "PreferNotToSay",
-              "No",
-              "Yes",
-              "Sometimes"
-            ],
-            "type": "string"
-          },
-          "EducationAttainedProfile": {
-            "enum": [
-              "PreferNotToSay",
-              "HighSchool",
-              "TradeSchool",
-              "InCollege",
-              "Undergraduate",
-              "InGradSchool",
-              "Graduate"
-            ],
-            "type": "string"
-          },
-          "Educations": {
-            "properties": {
-              "value": {
-                "items": {
-                  "type": "string"
-                },
-                "type": "array"
-              },
-              "visible": {
-                "type": "boolean"
-              }
-            },
-            "required": [
-              "value",
-              "visible"
-            ],
-            "type": "object"
-          },
-          "Ethnicities": {
-            "properties": {
-              "value": {
-                "items": {
-                  "$ref": "#/components/schemas/SelfProfileResponse/$defs/EthnicityProfile"
-                },
-                "type": "array"
-              },
-              "visible": {
-                "type": "boolean"
-              }
-            },
-            "required": [
-              "value",
-              "visible"
-            ],
-            "type": "object"
-          },
-          "EthnicityProfile": {
-            "enum": [
-              "PreferNotToSay",
-              "AmericanIndian",
-              "BlackAfrican",
-              "EastAsian",
-              "Hispanic",
-              "MiddleEastern",
-              "PacificIslander",
-              "SouthAsian",
-              "White",
-              "Other"
-            ],
-            "type": "string"
-          },
-          "FamilyPlans": {
-            "properties": {
-              "value": {
-                "format": "int32",
-                "type": "integer"
-              },
-              "visible": {
-                "type": "boolean"
-              }
-            },
-            "required": [
-              "value",
-              "visible"
-            ],
-            "type": "object"
-          },
-          "Feedback": {
-            "properties": {
-              "detail": {
-                "type": "string"
-              },
-              "evaluation": {
-                "type": "string"
-              },
-              "feedbackToken": {
-                "type": "string"
-              }
-            },
-            "required": [
-              "evaluation",
-              "detail",
-              "feedbackToken"
-            ],
-            "type": "object"
-          },
-          "GenderEnum": {
-            "enum": [
-              "Man",
-              "Woman",
-              "NonBinary"
-            ],
-            "type": "string"
-          },
-          "GenderIdentityId": {
-            "properties": {
-              "value": {
-                "format": "int32",
-                "type": "integer"
-              },
-              "visible": {
-                "type": "boolean"
-              }
-            },
-            "required": [
-              "value",
-              "visible"
-            ],
-            "type": "object"
-          },
-          "Hometown": {
-            "properties": {
-              "value": {
-                "type": "string"
-              },
-              "visible": {
-                "type": "boolean"
-              }
-            },
-            "required": [
-              "value",
-              "visible"
-            ],
-            "type": "object"
-          },
-          "JobTitle": {
-            "properties": {
-              "value": {
-                "type": "string"
-              },
-              "visible": {
-                "type": "boolean"
-              }
-            },
-            "required": [
-              "value",
-              "visible"
-            ],
-            "type": "object"
-          },
-          "LanguagesSpoken": {
-            "properties": {
-              "value": {
-                "items": {
-                  "format": "int32",
-                  "type": "integer"
-                },
-                "type": "array"
-              },
-              "visible": {
-                "type": "boolean"
-              }
-            },
-            "required": [
-              "value",
-              "visible"
-            ],
-            "type": "object"
-          },
-          "Location": {
-            "properties": {
-              "adminArea1Long": {
-                "type": [
-                  "string",
-                  "null"
-                ]
-              },
-              "adminArea1Short": {
-                "type": [
-                  "string",
-                  "null"
-                ]
-              },
-              "adminArea2": {
-                "type": [
-                  "string",
-                  "null"
-                ]
-              },
-              "countryShort": {
-                "type": [
-                  "string",
-                  "null"
-                ]
-              },
-              "latitude": {
-                "format": "double",
-                "type": [
-                  "number",
-                  "null"
-                ]
-              },
-              "longitude": {
-                "format": "double",
-                "type": [
-                  "number",
-                  "null"
-                ]
-              },
-              "metroArea": {
-                "type": [
-                  "string",
-                  "null"
-                ]
-              },
-              "metroAreaV2": {
-                "type": [
-                  "string",
-                  "null"
-                ]
-              },
-              "name": {
-                "type": "string"
-              }
-            },
-            "required": [
-              "name"
-            ],
-            "type": "object"
-          },
-          "MarijuanaStatus": {
-            "properties": {
-              "value": {
-                "$ref": "#/components/schemas/SelfProfileResponse/$defs/MarijuanaStatusProfile"
-              },
-              "visible": {
-                "type": "boolean"
-              }
-            },
-            "required": [
-              "value",
-              "visible"
-            ],
-            "type": "object"
-          },
-          "MarijuanaStatusProfile": {
-            "enum": [
-              "PreferNotToSay",
-              "No",
-              "Yes",
-              "Sometimes",
-              "NoPreference"
-            ],
-            "type": "string"
-          },
-          "PhotoAsset": {
-            "properties": {
-              "boundingBox": {
-                "anyOf": [
-                  {
-                    "$ref": "#/components/schemas/SelfProfileResponse/$defs/BoundingBox"
-                  },
-                  {
-                    "type": "null"
-                  }
-                ]
-              },
-              "caption": {
-                "type": [
-                  "string",
-                  "null"
-                ]
-              },
-              "cdnId": {
-                "type": [
-                  "string",
-                  "null"
-                ]
-              },
-              "contentId": {
-                "type": [
-                  "string",
-                  "null"
-                ]
-              },
-              "height": {
-                "format": "int32",
-                "type": [
-                  "integer",
-                  "null"
-                ]
-              },
-              "id": {
-                "type": [
-                  "string",
-                  "null"
-                ]
-              },
-              "location": {
-                "type": [
-                  "string",
-                  "null"
-                ]
-              },
-              "pHash": {
-                "type": [
-                  "string",
-                  "null"
-                ]
-              },
-              "promptId": {
-                "type": [
-                  "string",
-                  "null"
-                ]
-              },
-              "selfieVerified": {
-                "type": [
-                  "boolean",
-                  "null"
-                ]
-              },
-              "source": {
-                "type": [
-                  "string",
-                  "null"
-                ]
-              },
-              "sourceId": {
-                "type": [
-                  "string",
-                  "null"
-                ]
-              },
-              "url": {
-                "type": "string"
-              },
-              "videoUrl": {
-                "type": [
-                  "string",
-                  "null"
-                ]
-              },
-              "width": {
-                "format": "int32",
-                "type": [
-                  "integer",
-                  "null"
-                ]
-              }
-            },
-            "required": [
-              "url"
-            ],
-            "type": "object"
-          },
-          "Politics": {
-            "properties": {
-              "value": {
-                "$ref": "#/components/schemas/SelfProfileResponse/$defs/PoliticsProfile"
-              },
-              "visible": {
-                "type": "boolean"
-              }
-            },
-            "required": [
-              "value",
-              "visible"
-            ],
-            "type": "object"
-          },
-          "PoliticsProfile": {
-            "enum": [
-              "PreferNotToSay",
-              "Liberal",
-              "Moderate",
-              "Conservative",
-              "NotPolitical",
-              "Other"
-            ],
-            "type": "string"
-          },
-          "Profile": {
-            "properties": {
-              "age": {
-                "format": "int32",
-                "type": [
-                  "integer",
-                  "null"
-                ]
-              },
-              "answers": {
-                "default": [],
-                "items": {
-                  "$ref": "#/components/schemas/SelfProfileResponse/$defs/ProfileAnswer"
-                },
-                "type": "array"
-              },
-              "birthday": {
-                "type": [
-                  "string",
-                  "null"
-                ]
-              },
-              "children": {
-                "anyOf": [
-                  {
-                    "$ref": "#/components/schemas/SelfProfileResponse/$defs/ChildrenStatus"
-                  },
-                  {
-                    "type": "null"
-                  }
-                ]
-              },
-              "covidVax": {
-                "format": "int32",
-                "type": [
-                  "integer",
-                  "null"
-                ]
-              },
-              "datingIntention": {
-                "anyOf": [
-                  {
-                    "$ref": "#/components/schemas/SelfProfileResponse/$defs/DatingIntention"
-                  },
-                  {
-                    "type": "null"
-                  }
-                ]
-              },
-              "datingIntentionText": {
-                "type": [
-                  "string",
-                  "null"
-                ]
-              },
-              "didJustJoin": {
-                "type": [
-                  "boolean",
-                  "null"
-                ]
-              },
-              "drinking": {
-                "anyOf": [
-                  {
-                    "$ref": "#/components/schemas/SelfProfileResponse/$defs/DrinkingStatus"
-                  },
-                  {
-                    "type": "null"
-                  }
-                ]
-              },
-              "drugs": {
-                "anyOf": [
-                  {
-                    "$ref": "#/components/schemas/SelfProfileResponse/$defs/DrugStatus"
-                  },
-                  {
-                    "type": "null"
-                  }
-                ]
-              },
-              "educationAttained": {
-                "anyOf": [
-                  {
-                    "$ref": "#/components/schemas/SelfProfileResponse/$defs/EducationAttainedProfile"
-                  },
-                  {
-                    "type": "null"
-                  }
-                ]
-              },
-              "educations": {
-                "anyOf": [
-                  {
-                    "$ref": "#/components/schemas/SelfProfileResponse/$defs/Educations"
-                  },
-                  {
-                    "type": "null"
-                  }
-                ]
-              },
-              "email": {
-                "type": [
-                  "string",
-                  "null"
-                ]
-              },
-              "emailVerified": {
-                "type": [
-                  "boolean",
-                  "null"
-                ]
-              },
-              "ethnicities": {
-                "anyOf": [
-                  {
-                    "$ref": "#/components/schemas/SelfProfileResponse/$defs/Ethnicities"
-                  },
-                  {
-                    "type": "null"
-                  }
-                ]
-              },
-              "ethnicitiesText": {
-                "type": [
-                  "string",
-                  "null"
-                ]
-              },
-              "familyPlans": {
-                "anyOf": [
-                  {
-                    "$ref": "#/components/schemas/SelfProfileResponse/$defs/FamilyPlans"
-                  },
-                  {
-                    "type": "null"
-                  }
-                ]
-              },
-              "firstCompletedDate": {
-                "type": [
-                  "string",
-                  "null"
-                ]
-              },
-              "firstName": {
-                "type": "string"
-              },
-              "genderId": {
-                "anyOf": [
-                  {
-                    "$ref": "#/components/schemas/SelfProfileResponse/$defs/GenderEnum"
-                  },
-                  {
-                    "type": "null"
-                  }
-                ]
-              },
-              "genderIdentity": {
-                "type": [
-                  "string",
-                  "null"
-                ]
-              },
-              "genderIdentityId": {
-                "anyOf": [
-                  {
-                    "$ref": "#/components/schemas/SelfProfileResponse/$defs/GenderIdentityId"
-                  },
-                  {
-                    "type": "null"
-                  }
-                ]
-              },
-              "height": {
-                "format": "int32",
-                "type": [
-                  "integer",
-                  "null"
-                ]
-              },
-              "hometown": {
-                "anyOf": [
-                  {
-                    "$ref": "#/components/schemas/SelfProfileResponse/$defs/Hometown"
-                  },
-                  {
-                    "type": "null"
-                  }
-                ]
-              },
-              "jobTitle": {
-                "anyOf": [
-                  {
-                    "$ref": "#/components/schemas/SelfProfileResponse/$defs/JobTitle"
-                  },
-                  {
-                    "type": "null"
-                  }
-                ]
-              },
-              "languagesSpoken": {
-                "anyOf": [
-                  {
-                    "$ref": "#/components/schemas/SelfProfileResponse/$defs/LanguagesSpoken"
-                  },
-                  {
-                    "type": "null"
-                  }
-                ]
-              },
-              "lastActiveStatusId": {
-                "format": "int32",
-                "type": [
-                  "integer",
-                  "null"
-                ]
-              },
-              "lastName": {
-                "type": [
-                  "string",
-                  "null"
-                ]
-              },
-              "location": {
-                "$ref": "#/components/schemas/SelfProfileResponse/$defs/Location"
-              },
-              "marijuana": {
-                "anyOf": [
-                  {
-                    "$ref": "#/components/schemas/SelfProfileResponse/$defs/MarijuanaStatus"
-                  },
-                  {
-                    "type": "null"
-                  }
-                ]
-              },
-              "name": {
-                "anyOf": [
-                  {
-                    "$ref": "#/components/schemas/SelfProfileResponse/$defs/ProfileName"
-                  },
-                  {
-                    "type": "null"
-                  }
-                ]
-              },
-              "pets": true,
-              "phone": {
-                "type": [
-                  "string",
-                  "null"
-                ]
-              },
-              "photos": {
-                "default": [],
-                "items": {
-                  "$ref": "#/components/schemas/SelfProfileResponse/$defs/PhotoAsset"
-                },
-                "type": "array"
-              },
-              "politics": {
-                "anyOf": [
-                  {
-                    "$ref": "#/components/schemas/SelfProfileResponse/$defs/Politics"
-                  },
-                  {
-                    "type": "null"
-                  }
-                ]
-              },
-              "pronouns": {
-                "anyOf": [
-                  {
-                    "$ref": "#/components/schemas/SelfProfileResponse/$defs/Pronouns"
-                  },
-                  {
-                    "type": "null"
-                  }
-                ]
-              },
-              "relationshipTypeIds": {
-                "anyOf": [
-                  {
-                    "$ref": "#/components/schemas/SelfProfileResponse/$defs/RelationshipTypeIds"
-                  },
-                  {
-                    "type": "null"
-                  }
-                ]
-              },
-              "relationshipTypesText": {
-                "type": [
-                  "string",
-                  "null"
-                ]
-              },
-              "religions": {
-                "anyOf": [
-                  {
-                    "$ref": "#/components/schemas/SelfProfileResponse/$defs/Religion"
-                  },
-                  {
-                    "type": "null"
-                  }
-                ]
-              },
-              "selfieVerified": {
-                "type": [
-                  "boolean",
-                  "null"
-                ]
-              },
-              "sexualOrientations": {
-                "anyOf": [
-                  {
-                    "$ref": "#/components/schemas/SelfProfileResponse/$defs/SexualOrientations"
-                  },
-                  {
-                    "type": "null"
-                  }
-                ]
-              },
-              "smoking": {
-                "anyOf": [
-                  {
-                    "$ref": "#/components/schemas/SelfProfileResponse/$defs/SmokingStatus"
-                  },
-                  {
-                    "type": "null"
-                  }
-                ]
-              },
-              "works": {
-                "anyOf": [
-                  {
-                    "$ref": "#/components/schemas/SelfProfileResponse/$defs/Works"
-                  },
-                  {
-                    "type": "null"
-                  }
-                ]
-              },
-              "zodiac": {
-                "anyOf": [
-                  {
-                    "$ref": "#/components/schemas/SelfProfileResponse/$defs/Zodiac"
-                  },
-                  {
-                    "type": "null"
-                  }
-                ]
-              }
-            },
-            "required": [
-              "firstName",
-              "location"
-            ],
-            "type": "object"
-          },
-          "ProfileAnswer": {
-            "properties": {
-              "cdnId": {
-                "type": [
-                  "string",
-                  "null"
-                ]
-              },
-              "content": {
-                "type": [
-                  "string",
-                  "null"
-                ]
-              },
-              "contentId": {
-                "type": [
-                  "string",
-                  "null"
-                ]
-              },
-              "feedback": {
-                "anyOf": [
-                  {
-                    "$ref": "#/components/schemas/SelfProfileResponse/$defs/Feedback"
-                  },
-                  {
-                    "type": "null"
-                  }
-                ]
-              },
-              "position": {
-                "format": "int32",
-                "type": [
-                  "integer",
-                  "null"
-                ]
-              },
-              "promptId": {
-                "type": [
-                  "string",
-                  "null"
-                ]
-              },
-              "questionId": {
-                "type": [
-                  "string",
-                  "null"
-                ]
-              },
-              "response": {
-                "type": [
-                  "string",
-                  "null"
-                ]
-              },
-              "transcription": {
-                "type": [
-                  "string",
-                  "null"
-                ]
-              },
-              "transcriptionMetadata": true,
-              "type": {
-                "type": [
-                  "string",
-                  "null"
-                ]
-              },
-              "url": {
-                "type": [
-                  "string",
-                  "null"
-                ]
-              },
-              "waveform": {
-                "type": [
-                  "string",
-                  "null"
-                ]
-              }
-            },
-            "type": "object"
-          },
-          "ProfileName": {
-            "properties": {
-              "firstName": {
-                "type": "string"
-              },
-              "lastName": {
-                "default": null,
-                "type": [
-                  "string",
-                  "null"
-                ]
-              }
-            },
-            "required": [
-              "firstName"
-            ],
-            "type": "object"
-          },
-          "Pronouns": {
-            "properties": {
-              "value": {
-                "items": {
-                  "format": "int32",
-                  "type": "integer"
-                },
-                "type": "array"
-              },
-              "visible": {
-                "type": "boolean"
-              }
-            },
-            "required": [
-              "value",
-              "visible"
-            ],
-            "type": "object"
-          },
-          "RelationshipTypeIds": {
-            "properties": {
-              "value": {
-                "items": {
-                  "$ref": "#/components/schemas/SelfProfileResponse/$defs/RelationshipTypeProfile"
-                },
-                "type": "array"
-              },
-              "visible": {
-                "type": "boolean"
-              }
-            },
-            "required": [
-              "value",
-              "visible"
-            ],
-            "type": "object"
-          },
-          "RelationshipTypeProfile": {
-            "enum": [
-              "PreferNotToSay",
-              "Monogamy",
-              "EthicalNonMonogamy",
-              "FiguringOutTheirRelationshipType"
-            ],
-            "type": "string"
-          },
-          "Religion": {
-            "properties": {
-              "value": {
-                "items": {
-                  "$ref": "#/components/schemas/SelfProfileResponse/$defs/ReligionProfile"
-                },
-                "type": "array"
-              },
-              "visible": {
-                "type": "boolean"
-              }
-            },
-            "required": [
-              "value",
-              "visible"
-            ],
-            "type": "object"
-          },
-          "ReligionProfile": {
-            "enum": [
-              "PreferNotToSay",
-              "Spiritual",
-              "Catholic",
-              "Christian",
-              "Hindu",
-              "Jewish",
-              "Muslim",
-              "Buddhist",
-              "Agnostic",
-              "Atheist",
-              "Other",
-              "Sikh"
-            ],
-            "type": "string"
-          },
-          "SexualOrientations": {
-            "properties": {
-              "value": {
-                "items": {
-                  "format": "int32",
-                  "type": "integer"
-                },
-                "type": "array"
-              },
-              "visible": {
-                "type": "boolean"
-              }
-            },
-            "required": [
-              "value",
-              "visible"
-            ],
-            "type": "object"
-          },
-          "SmokingStatus": {
-            "properties": {
-              "value": {
-                "$ref": "#/components/schemas/SelfProfileResponse/$defs/SmokingStatusProfile"
-              },
-              "visible": {
-                "type": "boolean"
-              }
-            },
-            "required": [
-              "value",
-              "visible"
-            ],
-            "type": "object"
-          },
-          "SmokingStatusProfile": {
-            "enum": [
-              "PreferNotToSay",
-              "No",
-              "Yes",
-              "Sometimes"
-            ],
-            "type": "string"
-          },
-          "Works": {
-            "properties": {
-              "value": {
-                "type": "string"
-              },
-              "visible": {
-                "type": "boolean"
-              }
-            },
-            "required": [
-              "value",
-              "visible"
-            ],
-            "type": "object"
-          },
-          "Zodiac": {
-            "properties": {
-              "value": {
-                "format": "int32",
-                "type": "integer"
-              },
-              "visible": {
-                "type": "boolean"
-              }
-            },
-            "required": [
-              "value",
-              "visible"
-            ],
-            "type": "object"
-          }
-        },
         "properties": {
           "created": {
             "type": "string"
@@ -11497,7 +3906,7 @@
             "type": "boolean"
           },
           "profile": {
-            "$ref": "#/components/schemas/SelfProfileResponse/$defs/Profile"
+            "$ref": "#/components/schemas/Profile"
           },
           "registered": {
             "type": "string"
@@ -11519,19 +3928,6 @@
         "type": "object"
       },
       "SendMessagePayload": {
-        "$defs": {
-          "MessageData": {
-            "properties": {
-              "message": {
-                "type": "string"
-              }
-            },
-            "required": [
-              "message"
-            ],
-            "type": "object"
-          }
-        },
         "properties": {
           "ays": {
             "type": "boolean"
@@ -11546,7 +3942,7 @@
             "type": "boolean"
           },
           "messageData": {
-            "$ref": "#/components/schemas/SendMessagePayload/$defs/MessageData"
+            "$ref": "#/components/schemas/MessageData"
           },
           "messageType": {
             "type": "string"
@@ -11647,261 +4043,11 @@
         "type": "object"
       },
       "SendbirdChannelsResponse": {
-        "$defs": {
-          "SendbirdChannelMember": {
-            "properties": {
-              "is_active": {
-                "default": false,
-                "type": "boolean"
-              },
-              "metadata": {
-                "default": null
-              },
-              "nickname": {
-                "default": "",
-                "type": "string"
-              },
-              "profile_url": {
-                "default": "",
-                "type": "string"
-              },
-              "user_id": {
-                "default": "",
-                "type": "string"
-              }
-            },
-            "type": "object"
-          },
-          "SendbirdGroupChannel": {
-            "properties": {
-              "channel_url": {
-                "type": "string"
-              },
-              "cover_url": {
-                "default": "",
-                "type": "string"
-              },
-              "created_at": {
-                "default": "",
-                "type": "string"
-              },
-              "custom_type": {
-                "default": "",
-                "type": "string"
-              },
-              "joined_member_count": {
-                "default": 0,
-                "format": "int32",
-                "type": "integer"
-              },
-              "last_message": {
-                "anyOf": [
-                  {
-                    "$ref": "#/components/schemas/SendbirdChannelsResponse/$defs/SendbirdMessage"
-                  },
-                  {
-                    "type": "null"
-                  }
-                ],
-                "default": null
-              },
-              "member_count": {
-                "default": 0,
-                "format": "int32",
-                "type": "integer"
-              },
-              "members": {
-                "default": [],
-                "items": {
-                  "$ref": "#/components/schemas/SendbirdChannelsResponse/$defs/SendbirdChannelMember"
-                },
-                "type": "array"
-              },
-              "metadata": {
-                "default": null
-              },
-              "my_member_state": {
-                "default": "",
-                "type": "string"
-              },
-              "name": {
-                "default": "",
-                "type": "string"
-              },
-              "unread_message_count": {
-                "default": 0,
-                "format": "int32",
-                "type": "integer"
-              },
-              "updated_at": {
-                "default": "",
-                "type": "string"
-              }
-            },
-            "required": [
-              "channel_url"
-            ],
-            "type": "object"
-          },
-          "SendbirdMessage": {
-            "properties": {
-              "channel_type": {
-                "default": "",
-                "type": "string"
-              },
-              "channel_url": {
-                "type": "string"
-              },
-              "created_at": {
-                "type": "string"
-              },
-              "custom_type": {
-                "default": "",
-                "type": "string"
-              },
-              "data": {
-                "default": "",
-                "type": "string"
-              },
-              "file": {
-                "default": null
-              },
-              "is_op_msg": {
-                "default": false,
-                "type": "boolean"
-              },
-              "is_removed": {
-                "default": false,
-                "type": "boolean"
-              },
-              "mention_type": {
-                "default": "",
-                "type": "string"
-              },
-              "mentioned_users": {
-                "default": [],
-                "items": true,
-                "type": "array"
-              },
-              "message": {
-                "default": "",
-                "type": "string"
-              },
-              "message_events": {
-                "default": null
-              },
-              "message_id": {
-                "type": "string"
-              },
-              "message_retention_hour": {
-                "default": "",
-                "type": "string"
-              },
-              "message_survival_seconds": {
-                "default": "",
-                "type": "string"
-              },
-              "reactions_summary": {
-                "default": [],
-                "items": true,
-                "type": "array"
-              },
-              "silent": {
-                "default": false,
-                "type": "boolean"
-              },
-              "sorted_metaarray": {
-                "default": [],
-                "items": {
-                  "$ref": "#/components/schemas/SendbirdChannelsResponse/$defs/SendbirdMessageMetaItem"
-                },
-                "type": "array"
-              },
-              "translations": {
-                "default": null
-              },
-              "type": {
-                "type": "string"
-              },
-              "updated_at": {
-                "default": "",
-                "type": "string"
-              },
-              "user": {
-                "$ref": "#/components/schemas/SendbirdChannelsResponse/$defs/SendbirdMessageUser"
-              }
-            },
-            "required": [
-              "type",
-              "message_id",
-              "created_at",
-              "user",
-              "channel_url"
-            ],
-            "type": "object"
-          },
-          "SendbirdMessageMetaItem": {
-            "properties": {
-              "key": {
-                "type": "string"
-              },
-              "value": {
-                "items": {
-                  "type": "string"
-                },
-                "type": "array"
-              }
-            },
-            "required": [
-              "key",
-              "value"
-            ],
-            "type": "object"
-          },
-          "SendbirdMessageUser": {
-            "properties": {
-              "is_active": {
-                "default": false,
-                "type": "boolean"
-              },
-              "is_blocked_by_me": {
-                "default": false,
-                "type": "boolean"
-              },
-              "metadata": {
-                "default": null
-              },
-              "nickname": {
-                "default": "",
-                "type": "string"
-              },
-              "profile_url": {
-                "default": "",
-                "type": "string"
-              },
-              "require_auth_for_profile_image": {
-                "default": false,
-                "type": "boolean"
-              },
-              "role": {
-                "default": "",
-                "type": "string"
-              },
-              "user_id": {
-                "type": "string"
-              }
-            },
-            "required": [
-              "user_id"
-            ],
-            "type": "object"
-          }
-        },
         "properties": {
           "channels": {
             "default": [],
             "items": {
-              "$ref": "#/components/schemas/SendbirdChannelsResponse/$defs/SendbirdGroupChannel"
+              "$ref": "#/components/schemas/SendbirdGroupChannel"
             },
             "type": "array"
           }
@@ -11959,185 +4105,6 @@
         "type": "object"
       },
       "SendbirdGroupChannel": {
-        "$defs": {
-          "SendbirdChannelMember": {
-            "properties": {
-              "is_active": {
-                "default": false,
-                "type": "boolean"
-              },
-              "metadata": {
-                "default": null
-              },
-              "nickname": {
-                "default": "",
-                "type": "string"
-              },
-              "profile_url": {
-                "default": "",
-                "type": "string"
-              },
-              "user_id": {
-                "default": "",
-                "type": "string"
-              }
-            },
-            "type": "object"
-          },
-          "SendbirdMessage": {
-            "properties": {
-              "channel_type": {
-                "default": "",
-                "type": "string"
-              },
-              "channel_url": {
-                "type": "string"
-              },
-              "created_at": {
-                "type": "string"
-              },
-              "custom_type": {
-                "default": "",
-                "type": "string"
-              },
-              "data": {
-                "default": "",
-                "type": "string"
-              },
-              "file": {
-                "default": null
-              },
-              "is_op_msg": {
-                "default": false,
-                "type": "boolean"
-              },
-              "is_removed": {
-                "default": false,
-                "type": "boolean"
-              },
-              "mention_type": {
-                "default": "",
-                "type": "string"
-              },
-              "mentioned_users": {
-                "default": [],
-                "items": true,
-                "type": "array"
-              },
-              "message": {
-                "default": "",
-                "type": "string"
-              },
-              "message_events": {
-                "default": null
-              },
-              "message_id": {
-                "type": "string"
-              },
-              "message_retention_hour": {
-                "default": "",
-                "type": "string"
-              },
-              "message_survival_seconds": {
-                "default": "",
-                "type": "string"
-              },
-              "reactions_summary": {
-                "default": [],
-                "items": true,
-                "type": "array"
-              },
-              "silent": {
-                "default": false,
-                "type": "boolean"
-              },
-              "sorted_metaarray": {
-                "default": [],
-                "items": {
-                  "$ref": "#/components/schemas/SendbirdGroupChannel/$defs/SendbirdMessageMetaItem"
-                },
-                "type": "array"
-              },
-              "translations": {
-                "default": null
-              },
-              "type": {
-                "type": "string"
-              },
-              "updated_at": {
-                "default": "",
-                "type": "string"
-              },
-              "user": {
-                "$ref": "#/components/schemas/SendbirdGroupChannel/$defs/SendbirdMessageUser"
-              }
-            },
-            "required": [
-              "type",
-              "message_id",
-              "created_at",
-              "user",
-              "channel_url"
-            ],
-            "type": "object"
-          },
-          "SendbirdMessageMetaItem": {
-            "properties": {
-              "key": {
-                "type": "string"
-              },
-              "value": {
-                "items": {
-                  "type": "string"
-                },
-                "type": "array"
-              }
-            },
-            "required": [
-              "key",
-              "value"
-            ],
-            "type": "object"
-          },
-          "SendbirdMessageUser": {
-            "properties": {
-              "is_active": {
-                "default": false,
-                "type": "boolean"
-              },
-              "is_blocked_by_me": {
-                "default": false,
-                "type": "boolean"
-              },
-              "metadata": {
-                "default": null
-              },
-              "nickname": {
-                "default": "",
-                "type": "string"
-              },
-              "profile_url": {
-                "default": "",
-                "type": "string"
-              },
-              "require_auth_for_profile_image": {
-                "default": false,
-                "type": "boolean"
-              },
-              "role": {
-                "default": "",
-                "type": "string"
-              },
-              "user_id": {
-                "type": "string"
-              }
-            },
-            "required": [
-              "user_id"
-            ],
-            "type": "object"
-          }
-        },
         "properties": {
           "channel_url": {
             "type": "string"
@@ -12162,7 +4129,7 @@
           "last_message": {
             "anyOf": [
               {
-                "$ref": "#/components/schemas/SendbirdGroupChannel/$defs/SendbirdMessage"
+                "$ref": "#/components/schemas/SendbirdMessage"
               },
               {
                 "type": "null"
@@ -12178,7 +4145,7 @@
           "members": {
             "default": [],
             "items": {
-              "$ref": "#/components/schemas/SendbirdGroupChannel/$defs/SendbirdChannelMember"
+              "$ref": "#/components/schemas/SendbirdChannelMember"
             },
             "type": "array"
           },
@@ -12210,64 +4177,6 @@
         "type": "object"
       },
       "SendbirdMessage": {
-        "$defs": {
-          "SendbirdMessageMetaItem": {
-            "properties": {
-              "key": {
-                "type": "string"
-              },
-              "value": {
-                "items": {
-                  "type": "string"
-                },
-                "type": "array"
-              }
-            },
-            "required": [
-              "key",
-              "value"
-            ],
-            "type": "object"
-          },
-          "SendbirdMessageUser": {
-            "properties": {
-              "is_active": {
-                "default": false,
-                "type": "boolean"
-              },
-              "is_blocked_by_me": {
-                "default": false,
-                "type": "boolean"
-              },
-              "metadata": {
-                "default": null
-              },
-              "nickname": {
-                "default": "",
-                "type": "string"
-              },
-              "profile_url": {
-                "default": "",
-                "type": "string"
-              },
-              "require_auth_for_profile_image": {
-                "default": false,
-                "type": "boolean"
-              },
-              "role": {
-                "default": "",
-                "type": "string"
-              },
-              "user_id": {
-                "type": "string"
-              }
-            },
-            "required": [
-              "user_id"
-            ],
-            "type": "object"
-          }
-        },
         "properties": {
           "channel_type": {
             "default": "",
@@ -12337,7 +4246,7 @@
           "sorted_metaarray": {
             "default": [],
             "items": {
-              "$ref": "#/components/schemas/SendbirdMessage/$defs/SendbirdMessageMetaItem"
+              "$ref": "#/components/schemas/SendbirdMessageMetaItem"
             },
             "type": "array"
           },
@@ -12352,7 +4261,7 @@
             "type": "string"
           },
           "user": {
-            "$ref": "#/components/schemas/SendbirdMessage/$defs/SendbirdMessageUser"
+            "$ref": "#/components/schemas/SendbirdMessageUser"
           }
         },
         "required": [
@@ -12424,165 +4333,10 @@
         "type": "object"
       },
       "SendbirdMessagesResponse": {
-        "$defs": {
-          "SendbirdMessage": {
-            "properties": {
-              "channel_type": {
-                "default": "",
-                "type": "string"
-              },
-              "channel_url": {
-                "type": "string"
-              },
-              "created_at": {
-                "type": "string"
-              },
-              "custom_type": {
-                "default": "",
-                "type": "string"
-              },
-              "data": {
-                "default": "",
-                "type": "string"
-              },
-              "file": {
-                "default": null
-              },
-              "is_op_msg": {
-                "default": false,
-                "type": "boolean"
-              },
-              "is_removed": {
-                "default": false,
-                "type": "boolean"
-              },
-              "mention_type": {
-                "default": "",
-                "type": "string"
-              },
-              "mentioned_users": {
-                "default": [],
-                "items": true,
-                "type": "array"
-              },
-              "message": {
-                "default": "",
-                "type": "string"
-              },
-              "message_events": {
-                "default": null
-              },
-              "message_id": {
-                "type": "string"
-              },
-              "message_retention_hour": {
-                "default": "",
-                "type": "string"
-              },
-              "message_survival_seconds": {
-                "default": "",
-                "type": "string"
-              },
-              "reactions_summary": {
-                "default": [],
-                "items": true,
-                "type": "array"
-              },
-              "silent": {
-                "default": false,
-                "type": "boolean"
-              },
-              "sorted_metaarray": {
-                "default": [],
-                "items": {
-                  "$ref": "#/components/schemas/SendbirdMessagesResponse/$defs/SendbirdMessageMetaItem"
-                },
-                "type": "array"
-              },
-              "translations": {
-                "default": null
-              },
-              "type": {
-                "type": "string"
-              },
-              "updated_at": {
-                "default": "",
-                "type": "string"
-              },
-              "user": {
-                "$ref": "#/components/schemas/SendbirdMessagesResponse/$defs/SendbirdMessageUser"
-              }
-            },
-            "required": [
-              "type",
-              "message_id",
-              "created_at",
-              "user",
-              "channel_url"
-            ],
-            "type": "object"
-          },
-          "SendbirdMessageMetaItem": {
-            "properties": {
-              "key": {
-                "type": "string"
-              },
-              "value": {
-                "items": {
-                  "type": "string"
-                },
-                "type": "array"
-              }
-            },
-            "required": [
-              "key",
-              "value"
-            ],
-            "type": "object"
-          },
-          "SendbirdMessageUser": {
-            "properties": {
-              "is_active": {
-                "default": false,
-                "type": "boolean"
-              },
-              "is_blocked_by_me": {
-                "default": false,
-                "type": "boolean"
-              },
-              "metadata": {
-                "default": null
-              },
-              "nickname": {
-                "default": "",
-                "type": "string"
-              },
-              "profile_url": {
-                "default": "",
-                "type": "string"
-              },
-              "require_auth_for_profile_image": {
-                "default": false,
-                "type": "boolean"
-              },
-              "role": {
-                "default": "",
-                "type": "string"
-              },
-              "user_id": {
-                "type": "string"
-              }
-            },
-            "required": [
-              "user_id"
-            ],
-            "type": "object"
-          }
-        },
         "properties": {
           "messages": {
             "items": {
-              "$ref": "#/components/schemas/SendbirdMessagesResponse/$defs/SendbirdMessage"
+              "$ref": "#/components/schemas/SendbirdMessage"
             },
             "type": "array"
           }
@@ -12594,54 +4348,6 @@
         "type": "object"
       },
       "SendbirdReadResponse": {
-        "$defs": {
-          "SendbirdReadUser": {
-            "properties": {
-              "guest_id": {
-                "type": "string"
-              },
-              "id": {
-                "type": "string"
-              },
-              "image": {
-                "type": "string"
-              },
-              "is_active": {
-                "type": "boolean"
-              },
-              "is_ai_bot": {
-                "type": "boolean"
-              },
-              "is_bot": {
-                "type": "boolean"
-              },
-              "metadata": {
-                "default": null
-              },
-              "name": {
-                "type": "string"
-              },
-              "require_auth_for_profile_image": {
-                "type": "boolean"
-              },
-              "role": {
-                "type": "string"
-              }
-            },
-            "required": [
-              "name",
-              "image",
-              "require_auth_for_profile_image",
-              "guest_id",
-              "id",
-              "role",
-              "is_bot",
-              "is_ai_bot",
-              "is_active"
-            ],
-            "type": "object"
-          }
-        },
         "properties": {
           "channel_id": {
             "type": "string"
@@ -12671,7 +4377,7 @@
             "type": "string"
           },
           "user": {
-            "$ref": "#/components/schemas/SendbirdReadResponse/$defs/SendbirdReadUser"
+            "$ref": "#/components/schemas/SendbirdReadUser"
           }
         },
         "required": [
@@ -12735,34 +4441,6 @@
         "type": "object"
       },
       "SendbirdSyevEvent": {
-        "$defs": {
-          "SendbirdSyevUserData": {
-            "properties": {
-              "metadata": {
-                "default": null
-              },
-              "nickname": {
-                "default": "",
-                "type": "string"
-              },
-              "profile_url": {
-                "default": "",
-                "type": "string"
-              },
-              "require_auth_for_profile_image": {
-                "default": false,
-                "type": "boolean"
-              },
-              "user_id": {
-                "type": "string"
-              }
-            },
-            "required": [
-              "user_id"
-            ],
-            "type": "object"
-          }
-        },
         "properties": {
           "cat": {
             "format": "int32",
@@ -12784,7 +4462,7 @@
           "data": {
             "anyOf": [
               {
-                "$ref": "#/components/schemas/SendbirdSyevEvent/$defs/SendbirdSyevUserData"
+                "$ref": "#/components/schemas/SendbirdSyevUserData"
               },
               {
                 "type": "null"
@@ -12853,96 +4531,6 @@
         "type": "object"
       },
       "SendbirdWsEvent": {
-        "$defs": {
-          "SendbirdSyevEvent": {
-            "properties": {
-              "cat": {
-                "format": "int32",
-                "type": "integer"
-              },
-              "channel_id": {
-                "default": null,
-                "type": [
-                  "string",
-                  "null"
-                ]
-              },
-              "channel_type": {
-                "type": "string"
-              },
-              "channel_url": {
-                "type": "string"
-              },
-              "data": {
-                "anyOf": [
-                  {
-                    "$ref": "#/components/schemas/SendbirdWsEvent/$defs/SendbirdSyevUserData"
-                  },
-                  {
-                    "type": "null"
-                  }
-                ],
-                "default": null
-              },
-              "has_ai_bot": {
-                "default": false,
-                "type": "boolean"
-              },
-              "has_bot": {
-                "default": false,
-                "type": "boolean"
-              },
-              "is_access_code_required": {
-                "default": false,
-                "type": "boolean"
-              },
-              "is_super": {
-                "default": false,
-                "type": "boolean"
-              },
-              "sts": {
-                "default": "",
-                "type": "string"
-              },
-              "ts": {
-                "default": "",
-                "type": "string"
-              }
-            },
-            "required": [
-              "cat",
-              "channel_url",
-              "channel_type"
-            ],
-            "type": "object"
-          },
-          "SendbirdSyevUserData": {
-            "properties": {
-              "metadata": {
-                "default": null
-              },
-              "nickname": {
-                "default": "",
-                "type": "string"
-              },
-              "profile_url": {
-                "default": "",
-                "type": "string"
-              },
-              "require_auth_for_profile_image": {
-                "default": false,
-                "type": "boolean"
-              },
-              "user_id": {
-                "type": "string"
-              }
-            },
-            "required": [
-              "user_id"
-            ],
-            "type": "object"
-          }
-        },
         "oneOf": [
           {
             "properties": {
@@ -12984,7 +4572,7 @@
           {
             "properties": {
               "event": {
-                "$ref": "#/components/schemas/SendbirdWsEvent/$defs/SendbirdSyevEvent"
+                "$ref": "#/components/schemas/SendbirdSyevEvent"
               },
               "kind": {
                 "const": "typing",
@@ -13071,6 +4659,25 @@
         ],
         "title": "SendbirdWsEvent"
       },
+      "SexualOrientations": {
+        "properties": {
+          "value": {
+            "items": {
+              "format": "int32",
+              "type": "integer"
+            },
+            "type": "array"
+          },
+          "visible": {
+            "type": "boolean"
+          }
+        },
+        "required": [
+          "value",
+          "visible"
+        ],
+        "type": "object"
+      },
       "SkipInput": {
         "properties": {
           "origin": {
@@ -13093,6 +4700,39 @@
         ],
         "title": "SkipInput",
         "type": "object"
+      },
+      "SmokingStatus": {
+        "properties": {
+          "value": {
+            "$ref": "#/components/schemas/SmokingStatusProfile"
+          },
+          "visible": {
+            "type": "boolean"
+          }
+        },
+        "required": [
+          "value",
+          "visible"
+        ],
+        "type": "object"
+      },
+      "SmokingStatusPreference": {
+        "enum": [
+          "OpenToAll",
+          "No",
+          "Yes",
+          "Sometimes"
+        ],
+        "type": "string"
+      },
+      "SmokingStatusProfile": {
+        "enum": [
+          "PreferNotToSay",
+          "No",
+          "Yes",
+          "Sometimes"
+        ],
+        "type": "string"
       },
       "SmsInitiateRequest": {
         "additionalProperties": true,
@@ -13119,23 +4759,10 @@
         "type": "object"
       },
       "SortedLikesGroupV2": {
-        "$defs": {
-          "SortedLikeIdV2": {
-            "properties": {
-              "id": {
-                "type": "string"
-              }
-            },
-            "required": [
-              "id"
-            ],
-            "type": "object"
-          }
-        },
         "properties": {
           "data": {
             "items": {
-              "$ref": "#/components/schemas/SortedLikesGroupV2/$defs/SortedLikeIdV2"
+              "$ref": "#/components/schemas/SortedLikeIdV2"
             },
             "type": "array"
           },
@@ -13151,24 +4778,11 @@
         "type": "object"
       },
       "StandoutContent": {
-        "$defs": {
-          "StandoutMediaRef": {
-            "properties": {
-              "contentId": {
-                "type": "string"
-              }
-            },
-            "required": [
-              "contentId"
-            ],
-            "type": "object"
-          }
-        },
         "properties": {
           "photo": {
             "anyOf": [
               {
-                "$ref": "#/components/schemas/StandoutContent/$defs/StandoutMediaRef"
+                "$ref": "#/components/schemas/StandoutMediaRef"
               },
               {
                 "type": "null"
@@ -13179,7 +4793,7 @@
           "prompt": {
             "anyOf": [
               {
-                "$ref": "#/components/schemas/StandoutContent/$defs/StandoutMediaRef"
+                "$ref": "#/components/schemas/StandoutMediaRef"
               },
               {
                 "type": "null"
@@ -13192,49 +4806,9 @@
         "type": "object"
       },
       "StandoutItem": {
-        "$defs": {
-          "StandoutContent": {
-            "properties": {
-              "photo": {
-                "anyOf": [
-                  {
-                    "$ref": "#/components/schemas/StandoutItem/$defs/StandoutMediaRef"
-                  },
-                  {
-                    "type": "null"
-                  }
-                ],
-                "default": null
-              },
-              "prompt": {
-                "anyOf": [
-                  {
-                    "$ref": "#/components/schemas/StandoutItem/$defs/StandoutMediaRef"
-                  },
-                  {
-                    "type": "null"
-                  }
-                ],
-                "default": null
-              }
-            },
-            "type": "object"
-          },
-          "StandoutMediaRef": {
-            "properties": {
-              "contentId": {
-                "type": "string"
-              }
-            },
-            "required": [
-              "contentId"
-            ],
-            "type": "object"
-          }
-        },
         "properties": {
           "content": {
-            "$ref": "#/components/schemas/StandoutItem/$defs/StandoutContent"
+            "$ref": "#/components/schemas/StandoutContent"
           },
           "ratingToken": {
             "type": "string"
@@ -13264,65 +4838,6 @@
         "type": "object"
       },
       "StandoutsResponse": {
-        "$defs": {
-          "StandoutContent": {
-            "properties": {
-              "photo": {
-                "anyOf": [
-                  {
-                    "$ref": "#/components/schemas/StandoutsResponse/$defs/StandoutMediaRef"
-                  },
-                  {
-                    "type": "null"
-                  }
-                ],
-                "default": null
-              },
-              "prompt": {
-                "anyOf": [
-                  {
-                    "$ref": "#/components/schemas/StandoutsResponse/$defs/StandoutMediaRef"
-                  },
-                  {
-                    "type": "null"
-                  }
-                ],
-                "default": null
-              }
-            },
-            "type": "object"
-          },
-          "StandoutItem": {
-            "properties": {
-              "content": {
-                "$ref": "#/components/schemas/StandoutsResponse/$defs/StandoutContent"
-              },
-              "ratingToken": {
-                "type": "string"
-              },
-              "subjectId": {
-                "type": "string"
-              }
-            },
-            "required": [
-              "subjectId",
-              "ratingToken",
-              "content"
-            ],
-            "type": "object"
-          },
-          "StandoutMediaRef": {
-            "properties": {
-              "contentId": {
-                "type": "string"
-              }
-            },
-            "required": [
-              "contentId"
-            ],
-            "type": "object"
-          }
-        },
         "properties": {
           "expiration": {
             "default": null,
@@ -13334,7 +4849,7 @@
           "standouts": {
             "default": [],
             "items": {
-              "$ref": "#/components/schemas/StandoutsResponse/$defs/StandoutItem"
+              "$ref": "#/components/schemas/StandoutItem"
             },
             "type": "array"
           },
@@ -13418,45 +4933,9 @@
         "type": "array"
       },
       "VideoPrompt": {
-        "$defs": {
-          "BoundingBox": {
-            "properties": {
-              "bottomRight": {
-                "$ref": "#/components/schemas/VideoPrompt/$defs/Coordinate",
-                "default": {
-                  "x": 0.0,
-                  "y": 0.0
-                }
-              },
-              "topLeft": {
-                "$ref": "#/components/schemas/VideoPrompt/$defs/Coordinate",
-                "default": {
-                  "x": 0.0,
-                  "y": 0.0
-                }
-              }
-            },
-            "type": "object"
-          },
-          "Coordinate": {
-            "properties": {
-              "x": {
-                "default": 0.0,
-                "format": "double",
-                "type": "number"
-              },
-              "y": {
-                "default": 0.0,
-                "format": "double",
-                "type": "number"
-              }
-            },
-            "type": "object"
-          }
-        },
         "properties": {
           "boundingBox": {
-            "$ref": "#/components/schemas/VideoPrompt/$defs/BoundingBox"
+            "$ref": "#/components/schemas/BoundingBox"
           },
           "cdnId": {
             "type": "string"
@@ -13512,6 +4991,37 @@
         ],
         "title": "VoiceAnswerPayload",
         "type": "object"
+      },
+      "Works": {
+        "properties": {
+          "value": {
+            "type": "string"
+          },
+          "visible": {
+            "type": "boolean"
+          }
+        },
+        "required": [
+          "value",
+          "visible"
+        ],
+        "type": "object"
+      },
+      "Zodiac": {
+        "properties": {
+          "value": {
+            "format": "int32",
+            "type": "integer"
+          },
+          "visible": {
+            "type": "boolean"
+          }
+        },
+        "required": [
+          "value",
+          "visible"
+        ],
+        "type": "object"
       }
     },
     "securitySchemes": {
@@ -13535,6 +5045,7 @@
   "info": {
     "description": "Unofficial typed Hinge REST and Sendbird chat API surface generated from hinge-rs.",
     "license": {
+      "identifier": "MIT OR Apache-2.0",
       "name": "MIT OR Apache-2.0"
     },
     "title": "hinge-rs",
@@ -13545,15 +5056,11 @@
     "/auth/device/validate": {
       "post": {
         "description": "Completes the email-device validation flow when OTP returns email 2FA.",
+        "operationId": "submitEmail2faCode",
         "parameters": [],
         "requestBody": {
           "content": {
             "application/json": {
-              "examples": {
-                "request": {
-                  "value": {}
-                }
-              },
               "schema": {
                 "$ref": "#/components/schemas/EmailCodeRequest"
               }
@@ -13565,11 +5072,6 @@
           "200": {
             "content": {
               "application/json": {
-                "examples": {
-                  "success": {
-                    "value": {}
-                  }
-                },
                 "schema": {
                   "$ref": "#/components/schemas/LoginTokens"
                 }
@@ -13646,6 +5148,7 @@
             "description": "Server error"
           }
         },
+        "security": [],
         "summary": "Submit email 2FA code",
         "tags": [
           "Auth"
@@ -13655,16 +5158,12 @@
     "/auth/settings": {
       "get": {
         "description": "Fetches auth settings.",
+        "operationId": "getAuthSettings",
         "parameters": [],
         "responses": {
           "200": {
             "content": {
               "application/json": {
-                "examples": {
-                  "success": {
-                    "value": {}
-                  }
-                },
                 "schema": {
                   "$ref": "#/components/schemas/AuthSettings"
                 }
@@ -13755,6 +5254,7 @@
     "/auth/sms/v2": {
       "post": {
         "description": "Exchanges a phone number and OTP for Hinge and Sendbird tokens. A 412 response means email 2FA is required.",
+        "operationId": "submitSmsOtp",
         "parameters": [],
         "requestBody": {
           "content": {
@@ -13871,6 +5371,7 @@
             "description": "Server error"
           }
         },
+        "security": [],
         "summary": "Submit SMS OTP",
         "tags": [
           "Auth"
@@ -13880,6 +5381,7 @@
     "/auth/sms/v2/initiate": {
       "post": {
         "description": "Starts the SMS OTP login flow for a phone number.",
+        "operationId": "initiateSmsLogin",
         "parameters": [],
         "requestBody": {
           "content": {
@@ -13903,11 +5405,6 @@
           "200": {
             "content": {
               "application/json": {
-                "examples": {
-                  "success": {
-                    "value": {}
-                  }
-                },
                 "schema": {
                   "$ref": "#/components/schemas/EmptyObject"
                 }
@@ -13984,6 +5481,7 @@
             "description": "Server error"
           }
         },
+        "security": [],
         "summary": "Initiate SMS login",
         "tags": [
           "Auth"
@@ -13993,6 +5491,7 @@
     "/connection/subject/{subjectId}": {
       "get": {
         "description": "Fetches full detail for a connection subject.",
+        "operationId": "getConnectionDetail",
         "parameters": [
           {
             "description": "Subject ID",
@@ -14008,11 +5507,6 @@
           "200": {
             "content": {
               "application/json": {
-                "examples": {
-                  "success": {
-                    "value": {}
-                  }
-                },
                 "schema": {
                   "$ref": "#/components/schemas/ConnectionDetailApi"
                 }
@@ -14103,16 +5597,12 @@
     "/connection/v2": {
       "get": {
         "description": "Fetches current connections/matches.",
+        "operationId": "listConnections",
         "parameters": [],
         "responses": {
           "200": {
             "content": {
               "application/json": {
-                "examples": {
-                  "success": {
-                    "value": {}
-                  }
-                },
                 "schema": {
                   "$ref": "#/components/schemas/ConnectionsResponse"
                 }
@@ -14203,6 +5693,7 @@
     "/connection/v2/matchnote/{subjectId}": {
       "get": {
         "description": "Fetches match note for a subject.",
+        "operationId": "getMatchNote",
         "parameters": [
           {
             "description": "Subject ID",
@@ -14315,6 +5806,7 @@
     "/content/v1": {
       "delete": {
         "description": "Deletes profile content by comma-separated content IDs.",
+        "operationId": "deleteContent",
         "parameters": [
           {
             "description": "Comma-separated content IDs",
@@ -14330,11 +5822,6 @@
           "200": {
             "content": {
               "application/json": {
-                "examples": {
-                  "success": {
-                    "value": {}
-                  }
-                },
                 "schema": {
                   "$ref": "#/components/schemas/EmptyObject"
                 }
@@ -14425,15 +5912,11 @@
     "/content/v1/answer/evaluate": {
       "post": {
         "description": "Runs Hinge answer review before saving prompt content.",
+        "operationId": "evaluateAnswer",
         "parameters": [],
         "requestBody": {
           "content": {
             "application/json": {
-              "examples": {
-                "request": {
-                  "value": {}
-                }
-              },
               "schema": {
                 "$ref": "#/components/schemas/AnswerEvaluateRequest"
               }
@@ -14445,11 +5928,6 @@
           "200": {
             "content": {
               "application/json": {
-                "examples": {
-                  "success": {
-                    "value": {}
-                  }
-                },
                 "schema": {
                   "$ref": "#/components/schemas/RawJson"
                 }
@@ -14540,15 +6018,11 @@
     "/content/v1/answers": {
       "put": {
         "description": "Replaces answer content.",
+        "operationId": "updateAnswers",
         "parameters": [],
         "requestBody": {
           "content": {
             "application/json": {
-              "examples": {
-                "request": {
-                  "value": {}
-                }
-              },
               "schema": {
                 "$ref": "#/components/schemas/AnswersUpdateRequest"
               }
@@ -14560,11 +6034,6 @@
           "200": {
             "content": {
               "application/json": {
-                "examples": {
-                  "success": {
-                    "value": {}
-                  }
-                },
                 "schema": {
                   "$ref": "#/components/schemas/RawJson"
                 }
@@ -14655,15 +6124,11 @@
     "/content/v1/prompt_poll": {
       "post": {
         "description": "Creates prompt poll content.",
+        "operationId": "createPromptPoll",
         "parameters": [],
         "requestBody": {
           "content": {
             "application/json": {
-              "examples": {
-                "request": {
-                  "value": {}
-                }
-              },
               "schema": {
                 "$ref": "#/components/schemas/CreatePromptPollRequest"
               }
@@ -14675,11 +6140,6 @@
           "200": {
             "content": {
               "application/json": {
-                "examples": {
-                  "success": {
-                    "value": {}
-                  }
-                },
                 "schema": {
                   "$ref": "#/components/schemas/CreatePromptPollResponse"
                 }
@@ -14770,16 +6230,12 @@
     "/content/v1/settings": {
       "get": {
         "description": "Fetches content settings.",
+        "operationId": "getContentSettings",
         "parameters": [],
         "responses": {
           "200": {
             "content": {
               "application/json": {
-                "examples": {
-                  "success": {
-                    "value": {}
-                  }
-                },
                 "schema": {
                   "$ref": "#/components/schemas/UserSettings"
                 }
@@ -14868,15 +6324,11 @@
       },
       "patch": {
         "description": "Updates content settings.",
+        "operationId": "updateContentSettings",
         "parameters": [],
         "requestBody": {
           "content": {
             "application/json": {
-              "examples": {
-                "request": {
-                  "value": {}
-                }
-              },
               "schema": {
                 "$ref": "#/components/schemas/UserSettings"
               }
@@ -14888,11 +6340,6 @@
           "200": {
             "content": {
               "application/json": {
-                "examples": {
-                  "success": {
-                    "value": {}
-                  }
-                },
                 "schema": {
                   "$ref": "#/components/schemas/RawJson"
                 }
@@ -14983,15 +6430,11 @@
     "/content/v1/video_prompt": {
       "post": {
         "description": "Creates video prompt content.",
+        "operationId": "createVideoPrompt",
         "parameters": [],
         "requestBody": {
           "content": {
             "application/json": {
-              "examples": {
-                "request": {
-                  "value": {}
-                }
-              },
               "schema": {
                 "$ref": "#/components/schemas/CreateVideoPromptRequest"
               }
@@ -15003,11 +6446,6 @@
           "200": {
             "content": {
               "application/json": {
-                "examples": {
-                  "success": {
-                    "value": {}
-                  }
-                },
                 "schema": {
                   "$ref": "#/components/schemas/CreateVideoPromptResponse"
                 }
@@ -15098,16 +6536,12 @@
     "/content/v2": {
       "get": {
         "description": "Fetches photos, prompts, and other profile content for the authenticated user.",
+        "operationId": "getSelfContent",
         "parameters": [],
         "responses": {
           "200": {
             "content": {
               "application/json": {
-                "examples": {
-                  "success": {
-                    "value": {}
-                  }
-                },
                 "schema": {
                   "$ref": "#/components/schemas/SelfContentResponse"
                 }
@@ -15198,6 +6632,7 @@
     "/content/v2/public": {
       "get": {
         "description": "Fetches public content records by comma-separated user IDs.",
+        "operationId": "getPublicProfileContent",
         "parameters": [
           {
             "description": "Comma-separated user IDs",
@@ -15213,11 +6648,6 @@
           "200": {
             "content": {
               "application/json": {
-                "examples": {
-                  "success": {
-                    "value": {}
-                  }
-                },
                 "schema": {
                   "$ref": "#/components/schemas/PublicContentResponse"
                 }
@@ -15308,6 +6738,7 @@
     "/flag/textreview": {
       "post": {
         "description": "Runs Hinge text review and returns an HCM run ID used when sending notes/likes with comments.",
+        "operationId": "reviewMessageText",
         "parameters": [],
         "requestBody": {
           "content": {
@@ -15331,11 +6762,6 @@
           "200": {
             "content": {
               "application/json": {
-                "examples": {
-                  "success": {
-                    "value": {}
-                  }
-                },
                 "schema": {
                   "$ref": "#/components/schemas/TextReviewResponse"
                 }
@@ -15426,15 +6852,11 @@
     "/group_channels": {
       "post": {
         "description": "Creates a distinct Sendbird group channel.",
+        "operationId": "createSendbirdDmChannel",
         "parameters": [],
         "requestBody": {
           "content": {
             "application/json": {
-              "examples": {
-                "request": {
-                  "value": {}
-                }
-              },
               "schema": {
                 "$ref": "#/components/schemas/SendbirdCreateChannelRequest"
               }
@@ -15446,11 +6868,6 @@
           "200": {
             "content": {
               "application/json": {
-                "examples": {
-                  "success": {
-                    "value": {}
-                  }
-                },
                 "schema": {
                   "$ref": "#/components/schemas/RawJson"
                 }
@@ -15541,6 +6958,7 @@
     "/group_channels/{channelUrl}/messages": {
       "get": {
         "description": "Fetches message history around an optional timestamp anchor.",
+        "operationId": "getSendbirdMessages",
         "parameters": [
           {
             "description": "URL-encoded channel URL",
@@ -15574,11 +6992,6 @@
           "200": {
             "content": {
               "application/json": {
-                "examples": {
-                  "success": {
-                    "value": {}
-                  }
-                },
                 "schema": {
                   "$ref": "#/components/schemas/SendbirdMessagesResponse"
                 }
@@ -15669,6 +7082,7 @@
     "/identity/install": {
       "post": {
         "description": "Registers a generated install ID before SMS login.",
+        "operationId": "registerDeviceInstall",
         "parameters": [],
         "requestBody": {
           "content": {
@@ -15691,11 +7105,6 @@
           "200": {
             "content": {
               "application/json": {
-                "examples": {
-                  "success": {
-                    "value": {}
-                  }
-                },
                 "schema": {
                   "$ref": "#/components/schemas/EmptyObject"
                 }
@@ -15772,6 +7181,7 @@
             "description": "Server error"
           }
         },
+        "security": [],
         "summary": "Register device install",
         "tags": [
           "Auth"
@@ -15781,6 +7191,7 @@
     "/like/subject/{subjectId}": {
       "get": {
         "description": "Fetches one like by subject ID.",
+        "operationId": "getLikeSubject",
         "parameters": [
           {
             "description": "Subject ID",
@@ -15796,11 +7207,6 @@
           "200": {
             "content": {
               "application/json": {
-                "examples": {
-                  "success": {
-                    "value": {}
-                  }
-                },
                 "schema": {
                   "$ref": "#/components/schemas/LikeItemV2"
                 }
@@ -15891,16 +7297,12 @@
     "/like/v2": {
       "get": {
         "description": "Fetches inbound likes.",
+        "operationId": "listLikes",
         "parameters": [],
         "responses": {
           "200": {
             "content": {
               "application/json": {
-                "examples": {
-                  "success": {
-                    "value": {}
-                  }
-                },
                 "schema": {
                   "$ref": "#/components/schemas/LikesV2Response"
                 }
@@ -15991,6 +7393,7 @@
     "/likelimit": {
       "get": {
         "description": "Fetches remaining standard and super likes.",
+        "operationId": "getLikeLimit",
         "parameters": [],
         "responses": {
           "200": {
@@ -16094,6 +7497,7 @@
     "/message/authenticate": {
       "post": {
         "description": "Exchanges Hinge auth for a Sendbird JWT.",
+        "operationId": "authenticateSendbird",
         "parameters": [],
         "requestBody": {
           "content": {
@@ -16214,6 +7618,7 @@
     "/message/send": {
       "post": {
         "description": "Sends a message through Hinge after ensuring a Sendbird DM channel exists.",
+        "operationId": "sendHingeMessage",
         "parameters": [],
         "requestBody": {
           "content": {
@@ -16243,11 +7648,6 @@
           "200": {
             "content": {
               "application/json": {
-                "examples": {
-                  "success": {
-                    "value": {}
-                  }
-                },
                 "schema": {
                   "$ref": "#/components/schemas/RawJson"
                 }
@@ -16338,16 +7738,12 @@
     "/notification/v1/settings": {
       "get": {
         "description": "Fetches notification settings.",
+        "operationId": "getNotificationSettings",
         "parameters": [],
         "responses": {
           "200": {
             "content": {
               "application/json": {
-                "examples": {
-                  "success": {
-                    "value": {}
-                  }
-                },
                 "schema": {
                   "$ref": "#/components/schemas/NotificationSettings"
                 }
@@ -16438,16 +7834,12 @@
     "/preference/v2/selected": {
       "get": {
         "description": "Fetches selected dating preferences.",
+        "operationId": "getSelfPreferences",
         "parameters": [],
         "responses": {
           "200": {
             "content": {
               "application/json": {
-                "examples": {
-                  "success": {
-                    "value": {}
-                  }
-                },
                 "schema": {
                   "$ref": "#/components/schemas/PreferencesResponse"
                 }
@@ -16536,15 +7928,11 @@
       },
       "patch": {
         "description": "Updates selected dating preferences.",
+        "operationId": "updateSelfPreferences",
         "parameters": [],
         "requestBody": {
           "content": {
             "application/json": {
-              "examples": {
-                "request": {
-                  "value": {}
-                }
-              },
               "schema": {
                 "$ref": "#/components/schemas/PreferencesUpdateRequest"
               }
@@ -16556,11 +7944,6 @@
           "200": {
             "content": {
               "application/json": {
-                "examples": {
-                  "success": {
-                    "value": {}
-                  }
-                },
                 "schema": {
                   "$ref": "#/components/schemas/RawJson"
                 }
@@ -16651,15 +8034,11 @@
     "/prompts": {
       "post": {
         "description": "Fetches prompt catalog using a payload derived from profile and preferences.",
+        "operationId": "listPrompts",
         "parameters": [],
         "requestBody": {
           "content": {
             "application/json": {
-              "examples": {
-                "request": {
-                  "value": {}
-                }
-              },
               "schema": {
                 "$ref": "#/components/schemas/PromptPayload"
               }
@@ -16671,11 +8050,6 @@
           "200": {
             "content": {
               "application/json": {
-                "examples": {
-                  "success": {
-                    "value": {}
-                  }
-                },
                 "schema": {
                   "$ref": "#/components/schemas/PromptsResponse"
                 }
@@ -16766,15 +8140,11 @@
     "/rate/v2/initiate": {
       "post": {
         "description": "Creates a like, note, superlike, or skip rating.",
+        "operationId": "rateOrSkipUser",
         "parameters": [],
         "requestBody": {
           "content": {
             "application/json": {
-              "examples": {
-                "request": {
-                  "value": {}
-                }
-              },
               "schema": {
                 "$ref": "#/components/schemas/CreateRate"
               }
@@ -16786,11 +8156,6 @@
           "200": {
             "content": {
               "application/json": {
-                "examples": {
-                  "success": {
-                    "value": {}
-                  }
-                },
                 "schema": {
                   "$ref": "#/components/schemas/LikeResponse"
                 }
@@ -16881,15 +8246,11 @@
     "/rate/v2/respond": {
       "post": {
         "description": "Responds to an inbound like/match flow.",
+        "operationId": "respondToRate",
         "parameters": [],
         "requestBody": {
           "content": {
             "application/json": {
-              "examples": {
-                "request": {
-                  "value": {}
-                }
-              },
               "schema": {
                 "$ref": "#/components/schemas/RateRespondRequest"
               }
@@ -16901,11 +8262,6 @@
           "200": {
             "content": {
               "application/json": {
-                "examples": {
-                  "success": {
-                    "value": {}
-                  }
-                },
                 "schema": {
                   "$ref": "#/components/schemas/RateRespondResponse"
                 }
@@ -16996,6 +8352,7 @@
     "/rec/v2": {
       "post": {
         "description": "Fetches recommendation feeds for the authenticated user.",
+        "operationId": "getRecommendations",
         "parameters": [],
         "requestBody": {
           "content": {
@@ -17020,11 +8377,6 @@
           "200": {
             "content": {
               "application/json": {
-                "examples": {
-                  "success": {
-                    "value": {}
-                  }
-                },
                 "schema": {
                   "$ref": "#/components/schemas/RecommendationsResponse"
                 }
@@ -17115,15 +8467,11 @@
     "/sdk/chat/export": {
       "post": {
         "description": "SDK helper that fetches channel/profile context and writes a local markdown export. This is not a remote Hinge endpoint.",
+        "operationId": "exportChatHelper",
         "parameters": [],
         "requestBody": {
           "content": {
             "application/json": {
-              "examples": {
-                "request": {
-                  "value": {}
-                }
-              },
               "schema": {
                 "$ref": "#/components/schemas/ExportChatInput"
               }
@@ -17135,11 +8483,6 @@
           "200": {
             "content": {
               "application/json": {
-                "examples": {
-                  "success": {
-                    "value": {}
-                  }
-                },
                 "schema": {
                   "$ref": "#/components/schemas/ExportChatResult"
                 }
@@ -17230,6 +8573,7 @@
     "/sdk/group_channels/{channelUrl}": {
       "get": {
         "description": "Fetches a Sendbird group channel using the SDK endpoint.",
+        "operationId": "getSendbirdChannel",
         "parameters": [
           {
             "description": "URL-encoded channel URL",
@@ -17245,11 +8589,6 @@
           "200": {
             "content": {
               "application/json": {
-                "examples": {
-                  "success": {
-                    "value": {}
-                  }
-                },
                 "schema": {
                   "$ref": "#/components/schemas/SendbirdGroupChannel"
                 }
@@ -17340,9 +8679,27 @@
     "/sendbird/ws": {
       "get": {
         "description": "Pseudo-operation documenting the Sendbird WebSocket handshake and typed events. The Rust client connects to wss://ws-{appId}.sendbird.com/.",
+        "operationId": "connectSendbirdWebSocket",
         "responses": {
           "101": {
             "description": "WebSocket upgrade accepted"
+          },
+          "401": {
+            "content": {
+              "application/json": {
+                "examples": {
+                  "error": {
+                    "value": {
+                      "error": "Unauthorized"
+                    }
+                  }
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            },
+            "description": "Unauthorized"
           }
         },
         "security": [
@@ -17379,16 +8736,12 @@
     "/standouts/v3": {
       "get": {
         "description": "Fetches standout recommendations.",
+        "operationId": "getStandouts",
         "parameters": [],
         "responses": {
           "200": {
             "content": {
               "application/json": {
-                "examples": {
-                  "success": {
-                    "value": {}
-                  }
-                },
                 "schema": {
                   "$ref": "#/components/schemas/StandoutsResponse"
                 }
@@ -17479,16 +8832,12 @@
     "/store/v2/account": {
       "get": {
         "description": "Fetches account and subscription information.",
+        "operationId": "getAccountInfo",
         "parameters": [],
         "responses": {
           "200": {
             "content": {
               "application/json": {
-                "examples": {
-                  "success": {
-                    "value": {}
-                  }
-                },
                 "schema": {
                   "$ref": "#/components/schemas/AccountInfo"
                 }
@@ -17579,16 +8928,12 @@
     "/user/export/status": {
       "get": {
         "description": "Fetches account data export status.",
+        "operationId": "getExportStatus",
         "parameters": [],
         "responses": {
           "200": {
             "content": {
               "application/json": {
-                "examples": {
-                  "success": {
-                    "value": {}
-                  }
-                },
                 "schema": {
                   "$ref": "#/components/schemas/ExportStatus"
                 }
@@ -17679,16 +9024,12 @@
     "/user/repeat": {
       "get": {
         "description": "Requests repeated profiles from Hinge.",
+        "operationId": "repeatProfiles",
         "parameters": [],
         "responses": {
           "200": {
             "content": {
               "application/json": {
-                "examples": {
-                  "success": {
-                    "value": {}
-                  }
-                },
                 "schema": {
                   "$ref": "#/components/schemas/RawJson"
                 }
@@ -17779,16 +9120,12 @@
     "/user/v2/traits": {
       "get": {
         "description": "Fetches user traits.",
+        "operationId": "getUserTraits",
         "parameters": [],
         "responses": {
           "200": {
             "content": {
               "application/json": {
-                "examples": {
-                  "success": {
-                    "value": {}
-                  }
-                },
                 "schema": {
                   "$ref": "#/components/schemas/UserTraitsResponse"
                 }
@@ -17879,16 +9216,12 @@
     "/user/v3": {
       "get": {
         "description": "Fetches the authenticated user's profile.",
+        "operationId": "getSelfProfile",
         "parameters": [],
         "responses": {
           "200": {
             "content": {
               "application/json": {
-                "examples": {
-                  "success": {
-                    "value": {}
-                  }
-                },
                 "schema": {
                   "$ref": "#/components/schemas/SelfProfileResponse"
                 }
@@ -17977,15 +9310,11 @@
       },
       "patch": {
         "description": "Applies profile updates using Hinge's numeric enum wire format.",
+        "operationId": "updateSelfProfile",
         "parameters": [],
         "requestBody": {
           "content": {
             "application/json": {
-              "examples": {
-                "request": {
-                  "value": {}
-                }
-              },
               "schema": {
                 "$ref": "#/components/schemas/ProfileUpdateRequest"
               }
@@ -17997,11 +9326,6 @@
           "200": {
             "content": {
               "application/json": {
-                "examples": {
-                  "success": {
-                    "value": {}
-                  }
-                },
                 "schema": {
                   "$ref": "#/components/schemas/RawJson"
                 }
@@ -18092,6 +9416,7 @@
     "/user/v3/public": {
       "get": {
         "description": "Fetches public profile records by comma-separated user IDs.",
+        "operationId": "getPublicProfiles",
         "parameters": [
           {
             "description": "Comma-separated user IDs",
@@ -18107,11 +9432,6 @@
           "200": {
             "content": {
               "application/json": {
-                "examples": {
-                  "success": {
-                    "value": {}
-                  }
-                },
                 "schema": {
                   "$ref": "#/components/schemas/PublicProfilesResponse"
                 }
@@ -18202,6 +9522,7 @@
     "/users/{userId}/my_group_channels": {
       "get": {
         "description": "Lists Sendbird group channels for the authenticated user using the mobile SDK query shape.",
+        "operationId": "listMySendbirdChannels",
         "parameters": [
           {
             "description": "Sendbird user ID",
@@ -18253,11 +9574,6 @@
           "200": {
             "content": {
               "application/json": {
-                "examples": {
-                  "success": {
-                    "value": {}
-                  }
-                },
                 "schema": {
                   "$ref": "#/components/schemas/SendbirdChannelsResponse"
                 }
@@ -18363,36 +9679,47 @@
   ],
   "tags": [
     {
+      "description": "Device install, SMS OTP, email 2FA, and auth settings.",
       "name": "Auth"
     },
     {
+      "description": "Recommendation feeds, standouts, and repeat profiles.",
       "name": "Recommendations"
     },
     {
+      "description": "Self, public, and profile-content APIs.",
       "name": "Profiles"
     },
     {
+      "description": "Inbound likes, like limits, and like subject lookup.",
       "name": "Likes"
     },
     {
+      "description": "Like, note, superlike, skip, and response flows.",
       "name": "Ratings"
     },
     {
+      "description": "Prompt catalog and prompt-content creation.",
       "name": "Prompts"
     },
     {
+      "description": "Matches, connection detail, and match notes.",
       "name": "Connections"
     },
     {
+      "description": "Preferences, notifications, user traits, account, and export status.",
       "name": "Settings"
     },
     {
+      "description": "Hinge chat helpers and local export support.",
       "name": "Chat"
     },
     {
+      "description": "Sendbird channel, message, and group-channel endpoints used by Hinge chat.",
       "name": "Sendbird REST"
     },
     {
+      "description": "Documented Sendbird WebSocket handshake and typed frame events.",
       "name": "Sendbird WebSocket"
     }
   ],

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -1,6 +1,7 @@
 #![recursion_limit = "512"]
 
-use serde_json::{Value, json};
+use serde_json::{Map, Value, json};
+use std::collections::BTreeMap;
 use std::fs;
 use std::path::{Path, PathBuf};
 
@@ -279,7 +280,8 @@ fn openapi_document() -> Value {
             "version": hinge_rs::VERSION,
             "description": "Unofficial typed Hinge REST and Sendbird chat API surface generated from hinge-rs.",
             "license": {
-                "name": "MIT OR Apache-2.0"
+                "name": "MIT OR Apache-2.0",
+                "identifier": "MIT OR Apache-2.0"
             }
         },
         "servers": [
@@ -322,17 +324,17 @@ fn openapi_document() -> Value {
             }
         },
         "tags": [
-            {"name": "Auth"},
-            {"name": "Recommendations"},
-            {"name": "Profiles"},
-            {"name": "Likes"},
-            {"name": "Ratings"},
-            {"name": "Prompts"},
-            {"name": "Connections"},
-            {"name": "Settings"},
-            {"name": "Chat"},
-            {"name": "Sendbird REST"},
-            {"name": "Sendbird WebSocket"}
+            {"name": "Auth", "description": "Device install, SMS OTP, email 2FA, and auth settings."},
+            {"name": "Recommendations", "description": "Recommendation feeds, standouts, and repeat profiles."},
+            {"name": "Profiles", "description": "Self, public, and profile-content APIs."},
+            {"name": "Likes", "description": "Inbound likes, like limits, and like subject lookup."},
+            {"name": "Ratings", "description": "Like, note, superlike, skip, and response flows."},
+            {"name": "Prompts", "description": "Prompt catalog and prompt-content creation."},
+            {"name": "Connections", "description": "Matches, connection detail, and match notes."},
+            {"name": "Settings", "description": "Preferences, notifications, user traits, account, and export status."},
+            {"name": "Chat", "description": "Hinge chat helpers and local export support."},
+            {"name": "Sendbird REST", "description": "Sendbird channel, message, and group-channel endpoints used by Hinge chat."},
+            {"name": "Sendbird WebSocket", "description": "Documented Sendbird WebSocket handshake and typed frame events."}
         ],
         "paths": paths(),
         "components": components()
@@ -468,12 +470,14 @@ fn paths() -> Value {
             "get": {
                 "tags": ["Sendbird WebSocket"],
                 "summary": "Connect Sendbird WebSocket",
+                "operationId": "connectSendbirdWebSocket",
                 "description": "Pseudo-operation documenting the Sendbird WebSocket handshake and typed events. The Rust client connects to wss://ws-{appId}.sendbird.com/.",
                 "security": [{"sendbirdWsAuth": []}],
                 "responses": {
                     "101": {
                         "description": "WebSocket upgrade accepted"
-                    }
+                    },
+                    "401": error_response("Unauthorized")
                 },
                 "x-websocket-events": {
                     "client": ["READ", "PING", "TPST", "TPEN", "ENTR", "EXIT", "MACK", "CLOSE"],
@@ -712,6 +716,8 @@ fn schemas() -> Value {
     add_schema!(VoiceAnswerPayload);
     add_schema!(SendbirdWsEvent);
 
+    flatten_component_defs(&mut schemas);
+
     Value::Object(schemas)
 }
 
@@ -731,10 +737,10 @@ fn strip_schema_meta(schema: &mut Value) {
 fn rewrite_local_schema_refs(schema: &mut Value, component_name: &str) {
     match schema {
         Value::Object(map) => {
-            if let Some(Value::String(reference)) = map.get_mut("$ref") {
-                if let Some(suffix) = reference.strip_prefix("#/$defs/") {
-                    *reference = format!("#/components/schemas/{component_name}/$defs/{suffix}");
-                }
+            if let Some(Value::String(reference)) = map.get_mut("$ref")
+                && let Some(suffix) = reference.strip_prefix("#/$defs/")
+            {
+                *reference = format!("#/components/schemas/{component_name}/$defs/{suffix}");
             }
             for value in map.values_mut() {
                 rewrite_local_schema_refs(value, component_name);
@@ -743,6 +749,79 @@ fn rewrite_local_schema_refs(schema: &mut Value, component_name: &str) {
         Value::Array(values) => {
             for value in values {
                 rewrite_local_schema_refs(value, component_name);
+            }
+        }
+        _ => {}
+    }
+}
+
+fn flatten_component_defs(schemas: &mut Map<String, Value>) {
+    let mut component_defs = Vec::new();
+    for component_name in schemas.keys().cloned().collect::<Vec<_>>() {
+        let Some(schema) = schemas.get_mut(&component_name) else {
+            continue;
+        };
+        let Some(defs) = take_component_defs(schema) else {
+            continue;
+        };
+        component_defs.push((component_name, defs));
+    }
+
+    let mut ref_rewrites = BTreeMap::new();
+    let mut pending_schemas = BTreeMap::new();
+
+    for (component_name, defs) in component_defs {
+        for (def_name, def_schema) in defs {
+            let target_name = def_name.clone();
+            ref_rewrites.insert(
+                format!("#/components/schemas/{component_name}/$defs/{def_name}"),
+                format!("#/components/schemas/{target_name}"),
+            );
+
+            if !schemas.contains_key(&target_name) {
+                pending_schemas.entry(target_name).or_insert(def_schema);
+            }
+        }
+    }
+
+    for (name, schema) in pending_schemas {
+        schemas.entry(name).or_insert(schema);
+    }
+
+    for schema in schemas.values_mut() {
+        rewrite_schema_refs(schema, &ref_rewrites);
+    }
+}
+
+fn take_component_defs(schema: &mut Value) -> Option<Map<String, Value>> {
+    let Value::Object(map) = schema else {
+        return None;
+    };
+    match map.remove("$defs") {
+        Some(Value::Object(defs)) => Some(defs),
+        Some(defs) => {
+            map.insert("$defs".to_string(), defs);
+            None
+        }
+        None => None,
+    }
+}
+
+fn rewrite_schema_refs(schema: &mut Value, ref_rewrites: &BTreeMap<String, String>) {
+    match schema {
+        Value::Object(map) => {
+            if let Some(Value::String(reference)) = map.get_mut("$ref")
+                && let Some(replacement) = ref_rewrites.get(reference)
+            {
+                *reference = replacement.clone();
+            }
+            for value in map.values_mut() {
+                rewrite_schema_refs(value, ref_rewrites);
+            }
+        }
+        Value::Array(values) => {
+            for value in values {
+                rewrite_schema_refs(value, ref_rewrites);
             }
         }
         _ => {}
@@ -815,23 +894,28 @@ fn operation_with_params(
     response_schema: Option<Value>,
     hinge_auth: bool,
 ) -> Value {
+    let mut response_media = json!({
+        "schema": response_schema.unwrap_or_else(|| schema_ref("EmptyObject"))
+    });
+    if let Some(example) = example_for(summary) {
+        response_media["examples"] = json!({
+            "success": {
+                "value": example
+            }
+        });
+    }
+
     let mut op = json!({
         "tags": [tag],
         "summary": summary,
+        "operationId": operation_id(summary),
         "description": description,
         "parameters": parameters,
         "responses": {
             "200": {
                 "description": "Success",
                 "content": {
-                    "application/json": {
-                        "schema": response_schema.unwrap_or_else(|| schema_ref("EmptyObject")),
-                        "examples": {
-                            "success": {
-                                "value": example_for(summary)
-                            }
-                        }
-                    }
+                    "application/json": response_media
                 }
             },
             "400": error_response("Bad request"),
@@ -842,26 +926,53 @@ fn operation_with_params(
     });
 
     if let Some(schema) = request_schema {
+        let mut request_media = json!({
+            "schema": schema
+        });
+        if let Some(example) = request_example(summary) {
+            request_media["examples"] = json!({
+                "request": {
+                    "value": example
+                }
+            });
+        }
+
         op["requestBody"] = json!({
             "required": true,
             "content": {
-                "application/json": {
-                    "schema": schema,
-                    "examples": {
-                        "request": {
-                            "value": request_example(summary)
-                        }
-                    }
-                }
+                "application/json": request_media
             }
         });
     }
 
     if hinge_auth {
         op["security"] = json!([{"bearerAuth": []}]);
+    } else {
+        op["security"] = json!([]);
     }
 
     op
+}
+
+fn operation_id(summary: &str) -> String {
+    let mut words = summary
+        .split(|character: char| !character.is_ascii_alphanumeric())
+        .filter(|word| !word.is_empty());
+
+    let Some(first_word) = words.next() else {
+        return "operation".to_string();
+    };
+
+    let mut operation_id = first_word.to_ascii_lowercase();
+    for word in words {
+        let word = word.to_ascii_lowercase();
+        let mut chars = word.chars();
+        if let Some(first_character) = chars.next() {
+            operation_id.extend(first_character.to_uppercase());
+            operation_id.push_str(chars.as_str());
+        }
+    }
+    operation_id
 }
 
 fn schema_ref(name: &str) -> Value {
@@ -932,35 +1043,37 @@ fn generic_object(description: &str) -> Value {
     })
 }
 
-fn request_example(summary: &str) -> Value {
+fn request_example(summary: &str) -> Option<Value> {
     match summary {
-        "Register device install" => json!({"installId": "00000000-0000-0000-0000-000000000000"}),
-        "Initiate SMS login" => {
-            json!({"deviceId": "00000000-0000-0000-0000-000000000000", "phoneNumber": "+15555550123"})
+        "Register device install" => {
+            Some(json!({"installId": "00000000-0000-0000-0000-000000000000"}))
         }
-        "Submit SMS OTP" => {
-            json!({"installId": "00000000-0000-0000-0000-000000000000", "deviceId": "00000000-0000-0000-0000-000000000000", "phoneNumber": "+15555550123", "otp": "123456"})
-        }
+        "Initiate SMS login" => Some(
+            json!({"deviceId": "00000000-0000-0000-0000-000000000000", "phoneNumber": "+15555550123"}),
+        ),
+        "Submit SMS OTP" => Some(
+            json!({"installId": "00000000-0000-0000-0000-000000000000", "deviceId": "00000000-0000-0000-0000-000000000000", "phoneNumber": "+15555550123", "otp": "123456"}),
+        ),
         "Get recommendations" => {
-            json!({"playerId": "user_123", "newHere": false, "activeToday": false})
+            Some(json!({"playerId": "user_123", "newHere": false, "activeToday": false}))
         }
-        "Authenticate Sendbird" => json!({"refresh": false}),
-        "Review message text" => json!({"text": "hey", "receiverId": "user_456"}),
-        "Send Hinge message" => json!({
+        "Authenticate Sendbird" => Some(json!({"refresh": false})),
+        "Review message text" => Some(json!({"text": "hey", "receiverId": "user_456"})),
+        "Send Hinge message" => Some(json!({
             "ays": false,
             "matchMessage": true,
             "messageType": "text",
             "messageData": {"message": "hello"},
             "subjectId": "user_456",
             "origin": "connection"
-        }),
-        _ => json!({}),
+        })),
+        _ => None,
     }
 }
 
-fn example_for(summary: &str) -> Value {
+fn example_for(summary: &str) -> Option<Value> {
     match summary {
-        "Submit SMS OTP" => json!({
+        "Submit SMS OTP" => Some(json!({
             "hingeAuthToken": {
                 "identityId": "user_123",
                 "token": "[redacted]",
@@ -970,13 +1083,13 @@ fn example_for(summary: &str) -> Value {
                 "token": "[redacted]",
                 "expires": "2026-04-26T00:00:00Z"
             }
-        }),
-        "Get like limit" => json!({"likes": 8, "superlikes": 1}),
-        "Get match note" => json!({"note": "Liked your prompt"}),
+        })),
+        "Get like limit" => Some(json!({"likes": 8, "superlikes": 1})),
+        "Get match note" => Some(json!({"note": "Liked your prompt"})),
         "Authenticate Sendbird" => {
-            json!({"token": "[redacted]", "expires": "2026-04-26T00:00:00Z"})
+            Some(json!({"token": "[redacted]", "expires": "2026-04-26T00:00:00Z"}))
         }
-        _ => json!({}),
+        _ => None,
     }
 }
 
@@ -990,6 +1103,14 @@ mod tests {
         assert!(spec.get("x-scalar-environments").is_some());
         assert!(spec["paths"].get("/message/send").is_some());
         assert!(spec["paths"].get("/flag/textreview").is_some());
+        assert_eq!(
+            spec["paths"]["/identity/install"]["post"]["security"],
+            json!([])
+        );
+        assert_eq!(
+            spec["paths"]["/rec/v2"]["post"]["operationId"],
+            "getRecommendations"
+        );
         assert!(
             spec["paths"]
                 .get("/users/{userId}/my_group_channels")
@@ -1062,6 +1183,36 @@ mod tests {
     }
 
     #[test]
+    fn generated_openapi_uses_scalar_renderable_response_schemas() {
+        let spec = openapi_document();
+
+        assert!(
+            !has_defs_key(&spec),
+            "OpenAPI components should not keep $defs"
+        );
+        assert!(
+            !has_defs_ref(&spec),
+            "OpenAPI refs should not point into nested $defs"
+        );
+
+        let rec_media =
+            &spec["paths"]["/rec/v2"]["post"]["responses"]["200"]["content"]["application/json"];
+        assert_eq!(
+            rec_media["schema"]["$ref"],
+            "#/components/schemas/RecommendationsResponse"
+        );
+        assert!(
+            rec_media.get("examples").is_none(),
+            "unknown examples should be omitted instead of showing empty objects"
+        );
+        assert_eq!(
+            spec["components"]["schemas"]["RecommendationsResponse"]["properties"]["feeds"]["items"]
+                ["$ref"],
+            "#/components/schemas/RecommendationsFeed"
+        );
+    }
+
+    #[test]
     fn generated_versions_artifact_is_stable() {
         let crate_root = PathBuf::from(env!("CARGO_MANIFEST_DIR"))
             .parent()
@@ -1073,5 +1224,28 @@ mod tests {
         let actual =
             fs::read_to_string(artifact_path).expect("generated versions should be readable");
         assert_eq!(actual, expected);
+    }
+
+    fn has_defs_key(value: &Value) -> bool {
+        match value {
+            Value::Object(map) => map.contains_key("$defs") || map.values().any(has_defs_key),
+            Value::Array(values) => values.iter().any(has_defs_key),
+            _ => false,
+        }
+    }
+
+    fn has_defs_ref(value: &Value) -> bool {
+        match value {
+            Value::Object(map) => {
+                if let Some(Value::String(reference)) = map.get("$ref")
+                    && reference.contains("/$defs/")
+                {
+                    return true;
+                }
+                map.values().any(has_defs_ref)
+            }
+            Value::Array(values) => values.iter().any(has_defs_ref),
+            _ => false,
+        }
     }
 }


### PR DESCRIPTION
## Summary
- flatten generated OpenAPI component `` into top-level schemas so Scalar can render response fields
- omit empty success/request examples instead of showing `{}`
- add docs metadata needed by downstream OpenAPI tooling: explicit unauthenticated security, operation IDs, tag descriptions, and SPDX license metadata

## Validation
- `cargo test --locked`
- `cargo clippy --locked --all-targets --all-features -- -D warnings`
- `cargo test --locked --manifest-path xtask/Cargo.toml`
- `cargo clippy --locked --manifest-path xtask/Cargo.toml --all-targets -- -D warnings`
- `cargo fmt --check`
- `cargo fmt --manifest-path xtask/Cargo.toml -- --check`
- `npx --yes @redocly/cli@latest lint docs/api/openapi.json`