### PR TITLE
ci: publish before deploying release docs

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -73,4 +73,4 @@ jobs:
       url: ${{ steps.deployment.outputs.page_url }}
     steps:
       - id: deployment
-        uses: actions/deploy-pages@v4
+        uses: actions/deploy-pages@v5

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -106,6 +106,15 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
 
+      - name: Publish release
+        if: inputs.command == 'release' && !inputs['dry-run']
+        uses: release-plz/action@v0.5
+        with:
+          command: release
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
+
   deploy-docs:
     name: Deploy versioned docs
     if: inputs.command == 'release' && !inputs['dry-run']
@@ -140,13 +149,4 @@ jobs:
           path: ${{ runner.temp }}/pages
 
       - id: deployment
-        uses: actions/deploy-pages@v4
-
-      - name: Publish release
-        if: inputs.command == 'release' && !inputs['dry-run']
-        uses: release-plz/action@v0.5
-        with:
-          command: release
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
+        uses: actions/deploy-pages@v5


### PR DESCRIPTION
## Summary
- publish/tag with release-plz before building release docs
- deploy versioned docs after the tag exists
- update actions/deploy-pages to v5

## Validation
- actionlint .github/workflows/release.yml .github/workflows/docs.yml
- pre-push Rust checks