### PR TITLE
ci: use crates trusted publishing

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -76,8 +76,9 @@ jobs:
       - name: Verify crate package
         run: cargo package --locked
 
-  release:
-    name: release-plz ${{ inputs.command }}
+  release-pr:
+    name: Create or update release PR
+    if: inputs.command == 'release-pr'
     needs: verify
     runs-on: ubuntu-latest
     steps:
@@ -88,32 +89,52 @@ jobs:
       - uses: dtolnay/rust-toolchain@stable
       - uses: Swatinem/rust-cache@v2
 
-      - name: Create or update release PR
-        if: inputs.command == 'release-pr'
-        uses: release-plz/action@v0.5
+      - uses: release-plz/action@v0.5
         with:
           command: release-pr
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Dry-run release
-        if: inputs.command == 'release' && inputs['dry-run']
-        uses: release-plz/action@v0.5
+  release-dry-run:
+    name: Dry-run release
+    if: inputs.command == 'release' && inputs['dry-run']
+    needs: verify
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+      - uses: dtolnay/rust-toolchain@stable
+      - uses: Swatinem/rust-cache@v2
+
+      - uses: release-plz/action@v0.5
         with:
           command: release
           dry_run: true
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
 
-      - name: Publish release
-        if: inputs.command == 'release' && !inputs['dry-run']
-        uses: release-plz/action@v0.5
+  release:
+    name: Publish release
+    if: inputs.command == 'release' && !inputs['dry-run']
+    needs: verify
+    runs-on: ubuntu-latest
+    environment:
+      name: crates-io
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+      - uses: dtolnay/rust-toolchain@stable
+      - uses: Swatinem/rust-cache@v2
+
+      - uses: release-plz/action@v0.5
         with:
           command: release
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
 
   deploy-docs:
     name: Deploy versioned docs

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 [![CI](https://github.com/f0rr0/hinge-rs/actions/workflows/ci.yml/badge.svg)](https://github.com/f0rr0/hinge-rs/actions/workflows/ci.yml)
 [![API Reference](https://github.com/f0rr0/hinge-rs/actions/workflows/docs.yml/badge.svg)](https://f0rr0.github.io/hinge-rs/)
 [![MSRV](https://img.shields.io/badge/msrv-1.88-blue)](https://www.rust-lang.org)
-[![License](https://img.shields.io/crates/l/hinge-rs)](LICENSE-MIT)
+[![License](https://img.shields.io/badge/license-MIT%20OR%20Apache--2.0-blue)](https://github.com/f0rr0/hinge-rs#license)
 
 Unofficial, typed Rust client for Hinge APIs, including Sendbird chat.
 
@@ -53,3 +53,7 @@ async fn main() -> Result<(), hinge_rs::errors::HingeError> {
 ## Status
 
 Early OSS extraction. Unofficial and not affiliated with Hinge, Match Group, or Sendbird.
+
+## License
+
+Licensed under either [MIT](https://github.com/f0rr0/hinge-rs/blob/main/LICENSE-MIT) or [Apache-2.0](https://github.com/f0rr0/hinge-rs/blob/main/LICENSE-APACHE).


### PR DESCRIPTION
## Summary
- split release-plz into release-pr, dry-run, and publish jobs
- publish from the protected `crates-io` environment without `CARGO_REGISTRY_TOKEN`
- fix the README license badge/link so it works outside GitHub too

## Validation
- `actionlint .github/workflows/release.yml`
- `cargo fmt -- --check`
- `cargo test --locked`

## Notes
- The `crates-io` GitHub environment is configured to allow only protected branches; admins can bypass environment protection.
- crates.io trusted publishing must be configured for owner `f0rr0`, repo `hinge-rs`, workflow `release.yml`, environment `crates-io`.
